### PR TITLE
Added libcamera::ControlTypeRectangle parser

### DIFF
--- a/device/libcamera/device.cc
+++ b/device/libcamera/device.cc
@@ -173,8 +173,30 @@ int libcamera_device_set_option(device_t *dev, const char *keyp, const char *val
       control_value.set<float>(atof(value));
       break;
 
+    case libcamera::ControlTypeRectangle: {
+      std::string rectangle_regex_format = R"(\((\d+),(?:%20|\s)*(\d+)\)\/(\d+)x(\d+))";
+      std::regex rectangle_regex(rectangle_regex_format);
+
+      std::smatch rectangle_match;
+
+      std::string value_string(value);
+      std::regex_search(value_string, rectangle_match, rectangle_regex);
+
+      if (rectangle_match.empty()) {
+        LOG_ERROR(dev, "The value `%s` cannot be interpreted as a rectangle. Format expected to be `%s`, e.g. (0, 0)/1920x1080", value_string.c_str(), rectangle_regex_format.c_str());
+      } else {
+        int xpos = stoi(rectangle_match[1]);
+        int ypos = stoi(rectangle_match[2]);
+        unsigned int width = stoul(rectangle_match[3]);
+        unsigned int height = stoul(rectangle_match[4]);
+
+        libcamera::Rectangle rectangle(xpos, ypos, width, height);
+        control_value.set<libcamera::Rectangle>(rectangle);
+      }
+
+        break;
+    }
     case libcamera::ControlTypeString:
-    case libcamera::ControlTypeRectangle:
     case libcamera::ControlTypeSize:
       break;
     }

--- a/device/libcamera/libcamera.hh
+++ b/device/libcamera/libcamera.hh
@@ -18,6 +18,7 @@ extern "C" {
 #ifdef USE_LIBCAMERA
 #include <optional>
 #include <memory>
+#include <regex>
 
 #include <libcamera/controls.h>
 #include <libcamera/control_ids.h>


### PR DESCRIPTION
Added a C++ regex-based parser to parse the Rectangle data type. Uses the format (x, y)/widthxheight, which is the same as Rectangle::toString. Also accepts arbitrarily long white space / %20 chars between x and y in the format, so that url-space chars can be accepted. The data types should also be the same as Rectangle expects. 

See #28 for initial issue. I've tested that this implementation solves this problem.