### PR TITLE
Add option to specify IP address to bind for HTTP server.

### DIFF
--- a/cmd/camera-streamer/opts.c
+++ b/cmd/camera-streamer/opts.c
@@ -41,6 +41,7 @@ camera_options_t camera_options = {
 };
 
 http_server_options_t http_options = {
+  .addr = "0.0.0.0",
   .port = 8080,
   .maxcons = 10
 };
@@ -121,6 +122,7 @@ option_t all_options[] = {
 
   DEFINE_OPTION_DEFAULT(camera, list_options, bool, "1", "List all available options and exit."),
 
+  DEFINE_OPTION_PTR(http, addr, string, "Set the IP address the HTTP web-server will bind to."),
   DEFINE_OPTION(http, port, uint, "Set the HTTP web-server port."),
   DEFINE_OPTION(http, maxcons, uint, "Set maximum number of concurrent HTTP connections."),
 

--- a/util/http/http.c
+++ b/util/http/http.c
@@ -19,14 +19,14 @@
 #define HEADER_USER_AGENT "User-Agent:"
 #define HEADER_HOST "Host:"
 
-static int http_listen(int port, int maxcons)
+static int http_listen(char *addr, int port, int maxcons)
 {
   struct sockaddr_in server = {0};
   int listenfd = -1;
 
   // getaddrinfo for host
   server.sin_family = AF_INET;
-  server.sin_addr.s_addr = INADDR_ANY;
+  inet_aton(addr, &server.sin_addr);
   server.sin_port = htons(port);
 
   listenfd = socket(AF_INET, SOCK_STREAM, 0);
@@ -227,7 +227,7 @@ error:
 
 int http_server(http_server_options_t *options, http_method_t *methods)
 {
-  int listen_fd = http_listen(options->port, options->maxcons);
+  int listen_fd = http_listen(options->addr, options->port, options->maxcons);
   if (listen_fd < 0) {
     return -1;
   }

--- a/util/http/http.h
+++ b/util/http/http.h
@@ -26,6 +26,7 @@ typedef struct http_method_s {
 } http_method_t;
 
 typedef struct http_server_options_s {
+  char addr[16];
   unsigned port;
   unsigned maxcons;
 } http_server_options_t;


### PR DESCRIPTION
I want to have this behind a reverse proxy that provides authentication, so I added the option to specify the IP address to bind so that I can use `--http-addr=127.0.0.1`. Listening on a unix domain socket would be even better, but that's a much bigger change that I don't have the time or understanding for at the moment.

Thanks for creating this by the way, I had a lot of trouble with my raspi camera after upgrading to debian bullseye, and this is the first streamer I was actually able to get to work.