### PR TITLE
Adding trickle ICE support to speed up connection speeds and fully support the WebRTC protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = third_party/libdatachannel
 	url = https://github.com/paullouisageneau/libdatachannel.git
 	ignore = dirty
+[submodule "third_party/magic_enum"]
+	path = third_party/magic_enum
+	url = https://github.com/Neargye/magic_enum.git

--- a/README.md
+++ b/README.md
@@ -37,3 +37,15 @@ This section contains some advanced explanations that are not complete and might
 ## License
 
 GNU General Public License v3.0
+
+## References
+
+This project uses:
+
+- [WebRTC library libdatachannel](https://github.com/paullouisageneau/libdatachannel)
+- [Raspberry PI libcamera](https://github.com/raspberrypi/libcamera)
+- [RTSP live555](http://www.live555.com)
+- [FFmpeg](https://ffmpeg.org/)
+- [C++ helper magic_enum](https://github.com/Neargye/magic_enum)
+- [C++ JSON nlohmann](https://github.com/nlohmann/json)
+- [HTML from ESP32 Cam WebServer](https://github.com/easytarget/esp32-cam-webserver)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Release #{GIT_VERSION}
 
+- webrtc: accept `ice_servers` provided in `POST /webrtc`
+- webrtc: allow to specify ice-servers on command line
+
 ## Variants
 
 Download correct version for your platform:

--- a/cmd/camera-streamer/http.c
+++ b/cmd/camera-streamer/http.c
@@ -1,19 +1,17 @@
 #include "util/http/http.h"
-#include "util/opts/opts.h"
-#include "util/opts/log.h"
-#include "util/opts/fourcc.h"
 #include "output/webrtc/webrtc.h"
 #include "device/camera/camera.h"
 #include "output/output.h"
-#include "output/rtsp/rtsp.h"
 
 extern unsigned char html_index_html[];
 extern unsigned int html_index_html_len;
 extern unsigned char html_webrtc_html[];
 extern unsigned int html_webrtc_html_len;
+extern unsigned char html_control_html[];
+extern unsigned int html_control_html_len;
 extern camera_t *camera;
 
-void camera_status_json(http_worker_t *worker, FILE *stream);
+extern void camera_status_json(http_worker_t *worker, FILE *stream);
 
 static void http_once(FILE *stream, void (*fn)(FILE *stream, const char *data), void *headersp)
 {
@@ -25,12 +23,16 @@ static void http_once(FILE *stream, void (*fn)(FILE *stream, const char *data), 
   }
 }
 
-void *camera_http_set_option(http_worker_t *worker, FILE *stream, const char *key, const char *value, void *headersp)
+static void camera_post_option(http_worker_t *worker, FILE *stream)
 {
-  if (!camera) {
-    http_once(stream, http_500, headersp);
-    fprintf(stream, "No camera attached.\r\n");
-    return NULL;
+  char *device_name = http_get_param(worker, "device");
+  char *key = http_get_param(worker, "key");
+  char *value = http_get_param(worker, "value");
+
+  if (!key || !value) {
+    http_400(stream, "");
+    fprintf(stream, "No key or value passed.\r\n");
+    goto cleanup;;
   }
 
   bool found = false;
@@ -41,46 +43,33 @@ void *camera_http_set_option(http_worker_t *worker, FILE *stream, const char *ke
       continue;
     }
 
+    if (device_name && strcmp(dev->name, device_name)) {
+      continue;
+    }
+
     int ret = device_set_option_string(dev, key, value);
     if (ret > 0) {
-      http_once(stream, http_200, headersp);
+      http_once(stream, http_200, &found);
       fprintf(stream, "%s: The '%s' was set to '%s'.\r\n", dev->name, key, value);
     } else if (ret < 0) {
-      http_once(stream, http_500, headersp);
+      http_once(stream, http_500, &found);
       fprintf(stream, "%s: Cannot set '%s' to '%s'.\r\n", dev->name, key, value);
     }
-    found = true;
   }
 
-  if (found)
-    return NULL;
+  if (!found) {
+    http_once(stream, http_404, &found);
+    fprintf(stream, "The option was not found for device='%s', key='%s', value='%s'.\r\n",
+      device_name, key, value);
+  }
 
-  http_once(stream, http_404, headersp);
-  fprintf(stream, "The '%s' was set not found.\r\n", key);
-  return NULL;
+cleanup:
+  free(device_name);
+  free(key);
+  free(value);
 }
 
-void camera_http_option(http_worker_t *worker, FILE *stream)
-{
-  bool headers = false;
-  http_enum_params(worker, stream, camera_http_set_option, &headers);
-  if (headers) {
-    fprintf(stream, "---\r\n");
-  } else {
-    http_404(stream, "");
-    fprintf(stream, "No options passed.\r\n");
-  }
-
-  fprintf(stream, "\r\nSet: /option?name=value\r\n\r\n");
-
-  if (camera) {
-    for (int i = 0; i < MAX_DEVICES; i++) {
-      device_dump_options(camera->devices[i], stream);
-    }
-  }
-}
-
-void http_cors_options(http_worker_t *worker, FILE *stream)
+static void http_cors_options(http_worker_t *worker, FILE *stream)
 {
   fprintf(stream, "HTTP/1.1 204 No Data\r\n");
   fprintf(stream, "Access-Control-Allow-Origin: *\r\n");
@@ -102,7 +91,8 @@ http_method_t http_methods[] = {
   { "GET",  "/video.mp4", http_mp4_video },
   { "GET",  "/webrtc", http_content, "text/html", html_webrtc_html, 0, &html_webrtc_html_len },
   { "POST", "/webrtc", http_webrtc_offer },
-  { "GET",  "/option", camera_http_option },
+  { "GET",  "/option", http_content, "text/html", html_control_html, 0, &html_control_html_len },
+  { "POST", "/option", camera_post_option },
   { "GET",  "/status", camera_status_json },
   { "GET",  "/", http_content, "text/html", html_index_html, 0, &html_index_html_len },
   { "OPTIONS", "*/", http_cors_options },

--- a/cmd/camera-streamer/opts.c
+++ b/cmd/camera-streamer/opts.c
@@ -38,8 +38,8 @@ camera_options_t camera_options = {
       "video_bitrate=2000000" OPTION_VALUE_LIST_SEP
       "repeat_sequence_header=5000000" OPTION_VALUE_LIST_SEP
       "h264_i_frame_period=30" OPTION_VALUE_LIST_SEP
-      "h264_level=11" OPTION_VALUE_LIST_SEP
-      "h264_profile=4" OPTION_VALUE_LIST_SEP
+      "h264_level=4" OPTION_VALUE_LIST_SEP
+      "h264_profile=high" OPTION_VALUE_LIST_SEP
       "h264_minimum_qp_value=16" OPTION_VALUE_LIST_SEP
       "h264_maximum_qp_value=32"
   }

--- a/cmd/camera-streamer/opts.c
+++ b/cmd/camera-streamer/opts.c
@@ -131,6 +131,8 @@ option_t all_options[] = {
 
   DEFINE_OPTION_DEFAULT(rtsp, port, uint, "8554", "Set the RTSP server port (default: 8854)."),
 
+  DEFINE_OPTION_PTR(webrtc, ice_servers, list, "Specify ICE servers: [(stun|turn|turns)(:|://)][username:password@]hostname[:port][?transport=udp|tcp|tls)]."),
+
   DEFINE_OPTION_DEFAULT(log, debug, bool, "1", "Enable debug logging."),
   DEFINE_OPTION_DEFAULT(log, verbose, bool, "1", "Enable verbose logging."),
   DEFINE_OPTION_DEFAULT(log, stats, uint, "1", "Print statistics every duration."),

--- a/cmd/camera-streamer/opts.c
+++ b/cmd/camera-streamer/opts.c
@@ -132,6 +132,7 @@ option_t all_options[] = {
   DEFINE_OPTION_DEFAULT(rtsp, port, uint, "8554", "Set the RTSP server port (default: 8854)."),
 
   DEFINE_OPTION_PTR(webrtc, ice_servers, list, "Specify ICE servers: [(stun|turn|turns)(:|://)][username:password@]hostname[:port][?transport=udp|tcp|tls)]."),
+  DEFINE_OPTION_DEFAULT(webrtc, disable_client_ice, bool, "1", "Ignore ICE servers provided in '/webrtc' request."),
 
   DEFINE_OPTION_DEFAULT(log, debug, bool, "1", "Enable debug logging."),
   DEFINE_OPTION_DEFAULT(log, verbose, bool, "1", "Enable verbose logging."),

--- a/cmd/camera-streamer/opts.c
+++ b/cmd/camera-streamer/opts.c
@@ -111,6 +111,11 @@ option_t all_options[] = {
   DEFINE_OPTION_DEFAULT(camera, vflip, bool, "1", "Do vertical image flip (does not work with all camera)."),
   DEFINE_OPTION_DEFAULT(camera, hflip, bool, "1", "Do horizontal image flip (does not work with all camera)."),
 
+  DEFINE_OPTION(camera, crop.left, float, "Set the image crop."),
+  DEFINE_OPTION(camera, crop.top, float, "Set the image crop."),
+  DEFINE_OPTION(camera, crop.right, float, "Set the image crop."),
+  DEFINE_OPTION(camera, crop.bottom, float, "Set the image crop."),
+
   DEFINE_OPTION_PTR(camera, isp.options, list, "Set the ISP processing options. List all available options with `-camera-list_options`."),
 
   DEFINE_OPTION_PTR(camera, snapshot.options, list, "Set the JPEG compression options. List all available options with `-camera-list_options`."),

--- a/device/buffer_list.h
+++ b/device/buffer_list.h
@@ -22,6 +22,10 @@ typedef struct buffer_format_s {
   buffer_type_t type;
 } buffer_format_t;
 
+typedef struct buffer_rect_s {
+  unsigned x, y, width, height;
+} buffer_rect_t;
+
 typedef struct buffer_stats_s {
   int frames, dropped;
 } buffer_stats_t;
@@ -37,7 +41,7 @@ typedef struct buffer_list_s {
   int index;
 
   buffer_format_t fmt;
-  bool do_mmap, do_capture, do_timestamps;
+  bool do_mmap, do_capture, do_timestamps, do_not_find;
 
   union {
     struct buffer_list_v4l2_s *v4l2;

--- a/device/camera/camera.h
+++ b/device/camera/camera.h
@@ -25,9 +25,14 @@ typedef struct camera_output_options_s {
   char options[CAMERA_OPTIONS_LENGTH];
 } camera_output_options_t;
 
+typedef struct camera_crop_s {
+  float left, top, right, bottom;
+} camera_crop_t;
+
 typedef struct camera_options_s {
   char path[256];
   unsigned width, height, format;
+  camera_crop_t crop;
   unsigned nbufs, fps;
   camera_type_t type;
   bool allow_dma;
@@ -93,11 +98,14 @@ void camera_capture_add_output(camera_t *camera, buffer_list_t *capture, buffer_
 void camera_capture_add_callbacks(camera_t *camera, buffer_list_t *capture, link_callbacks_t callbacks);
 
 int camera_configure_input(camera_t *camera);
-int camera_configure_pipeline(camera_t *camera, buffer_list_t *camera_capture);
+int camera_configure_pipeline(camera_t *camera, buffer_list_t *camera_capture, camera_crop_t *crop);
 void camera_debug_capture(camera_t *camera, buffer_list_t *capture);
+
+bool camera_uses_crop(camera_crop_t *crop);
+int camera_configure_crop(device_t *dev, buffer_format_t fmt, camera_crop_t *crop);
 
 buffer_list_t *camera_configure_isp(camera_t *camera, buffer_list_t *src_capture);
 buffer_list_t *camera_configure_decoder(camera_t *camera, buffer_list_t *src_capture);
 buffer_list_t *camera_configure_rescaller(camera_t *camera, buffer_list_t *src_capture, const char *name, unsigned target_height, unsigned formats[]);
-int camera_configure_output(camera_t *camera, buffer_list_t *camera_capture, const char *name, camera_output_options_t *options, unsigned formats[], link_callbacks_t callbacks, device_t **device);
+int camera_configure_output(camera_t *camera, buffer_list_t *camera_capture, const char *name, camera_crop_t *crop, camera_output_options_t *options, unsigned formats[], link_callbacks_t callbacks, device_t **device);
 bool camera_get_scaled_resolution(buffer_format_t capture_format, camera_output_options_t *options, buffer_format_t *format, int align_size);

--- a/device/camera/camera_crop.c
+++ b/device/camera/camera_crop.c
@@ -1,0 +1,48 @@
+#include "camera.h"
+
+#include "device/buffer_list.h"
+#include "device/device.h"
+#include "util/opts/log.h"
+
+bool camera_uses_crop(camera_crop_t *crop)
+{
+  if (!crop) {
+    return false;
+  }
+
+  if (crop->left <= 0 && crop->right <= 0 &&
+    crop->top <= 0 && crop->bottom <= 0) {
+    return false;
+  }
+
+  return true;
+}
+
+int camera_configure_crop(device_t *dev, buffer_format_t fmt, camera_crop_t *crop)
+{
+  if (!camera_uses_crop(crop))
+    return 0;
+
+  int x = fmt.width * crop->left;
+  int y = fmt.height * crop->top;
+  int width = fmt.width * (1.0 - crop->left - crop->right);
+  int height = fmt.height * (1.0 - crop->top - crop->bottom);
+
+  if (x < 0 || y < 0 || width <= 1 || height <= 1) {
+    LOG_INFO(dev, "CROP settings do not make sense: %dx%d/(%dx%d)",
+      x, y, width, height);
+    return -1;
+  }
+
+  LOG_INFO(dev, "CROP: %dx%d/(%dx%d)",
+    x, y, width, height);
+
+  buffer_rect_t rect = {
+    .x = x,
+    .y = y,
+    .width = width,
+    .height = height,
+  };
+
+  return device_set_target_crop(dev, &rect);
+}

--- a/device/camera/camera_input.c
+++ b/device/camera/camera_input.c
@@ -44,7 +44,14 @@ static int camera_configure_input_v4l2(camera_t *camera)
     return -1;
   }
 
-  return camera_configure_pipeline(camera, camera_capture);
+  camera_crop_t *crop = NULL;
+
+  if (camera_uses_crop(&camera->options.crop)) {
+    camera_capture->do_not_find = true;
+    crop = &camera->options.crop;
+  }
+
+  return camera_configure_pipeline(camera, camera_capture, crop);
 }
 
 static int camera_configure_input_libcamera(camera_t *camera)
@@ -98,7 +105,14 @@ static int camera_configure_input_libcamera(camera_t *camera)
     return -1;
   }
 
-  return camera_configure_pipeline(camera, camera_capture);
+  camera_crop_t *crop = NULL;
+
+  if (camera_uses_crop(&camera->options.crop)) {
+    camera_capture->do_not_find = true;
+    crop = &camera->options.crop;
+  }
+
+  return camera_configure_pipeline(camera, camera_capture, crop);
 }
 
 static int camera_configure_input_dummy(camera_t *camera)
@@ -120,7 +134,14 @@ static int camera_configure_input_dummy(camera_t *camera)
     return -1;
   }
 
-  return camera_configure_pipeline(camera, camera_capture);
+  camera_crop_t *crop = NULL;
+
+  if (camera_uses_crop(&camera->options.crop)) {
+    camera_capture->do_not_find = true;
+    crop = &camera->options.crop;
+  }
+
+  return camera_configure_pipeline(camera, camera_capture, crop);
 }
 
 int camera_configure_input(camera_t *camera)

--- a/device/camera/camera_pipeline.c
+++ b/device/camera/camera_pipeline.c
@@ -42,23 +42,23 @@ static link_callbacks_t video_callbacks =
   .buf_lock = &video_lock
 };
 
-int camera_configure_pipeline(camera_t *camera, buffer_list_t *camera_capture)
+int camera_configure_pipeline(camera_t *camera, buffer_list_t *camera_capture, camera_crop_t *crop)
 {
   camera_capture->do_timestamps = true;
 
   camera_debug_capture(camera, camera_capture);
 
-  if (camera_configure_output(camera, camera_capture, "SNAPSHOT", &camera->options.snapshot,
+  if (camera_configure_output(camera, camera_capture, "SNAPSHOT", crop, &camera->options.snapshot,
     snapshot_formats, snapshot_callbacks, &camera->codec_snapshot) < 0) {
     return -1;
   }
 
-  if (camera_configure_output(camera, camera_capture, "STREAM", &camera->options.stream,
+  if (camera_configure_output(camera, camera_capture, "STREAM", crop, &camera->options.stream,
     snapshot_formats, stream_callbacks, &camera->codec_stream) < 0) {
     return -1;
   }
 
-  if (camera_configure_output(camera, camera_capture, "VIDEO", &camera->options.video,
+  if (camera_configure_output(camera, camera_capture, "VIDEO", crop, &camera->options.video,
     video_formats, video_callbacks, &camera->codec_video) < 0) {
     return -1;
   }

--- a/device/device.c
+++ b/device/device.c
@@ -194,6 +194,14 @@ void device_dump_options(device_t *dev, FILE *stream)
   }
 }
 
+int device_dump_options2(device_t *dev, device_option_fn fn, void *opaque)
+{
+  if (dev && dev->hw->device_dump_options) {
+    return dev->hw->device_dump_options2(dev, fn, opaque);
+  }
+  return -1;
+}
+
 int device_set_fps(device_t *dev, int desired_fps)
 {
   if (!dev)

--- a/device/device.c
+++ b/device/device.c
@@ -233,6 +233,18 @@ int device_set_rotation(device_t *dev, bool vflip, bool hflip)
   return hret ? hret : vret;
 }
 
+int device_set_target_crop(device_t *dev, const buffer_rect_t *rect)
+{
+  if (!dev || !rect)
+    return -1;
+
+  if (dev->hw->device_set_target_crop) {
+    return dev->hw->device_set_target_crop(dev, rect);
+  }
+
+  return -1;
+}
+
 int device_set_option_string(device_t *dev, const char *key, const char *value)
 {
   if (dev && dev->hw->device_set_option) {

--- a/device/device.h
+++ b/device/device.h
@@ -8,14 +8,18 @@ typedef struct buffer_s buffer_t;
 typedef struct buffer_list_s buffer_list_t;
 typedef struct buffer_format_s buffer_format_t;
 typedef struct buffer_rect_s buffer_rect_t;
+typedef struct device_option_s device_option_t;
 typedef struct device_s device_t;
 struct pollfd;
+
+typedef int device_option_fn(device_option_t *option, void *opaque);
 
 typedef struct device_hw_s {
   int (*device_open)(device_t *dev);
   void (*device_close)(device_t *dev);
   int (*device_video_force_key)(device_t *dev);
   void (*device_dump_options)(device_t *dev, FILE *stream);
+  int (*device_dump_options2)(device_t *dev, device_option_fn fn, void *opaque);
   int (*device_set_fps)(device_t *dev, int desired_fps);
   int (*device_set_rotation)(device_t *dev, bool vflip, bool hflip);
   int (*device_set_option)(device_t *dev, const char *key, const char *value);
@@ -57,6 +61,42 @@ typedef struct device_s {
   bool paused;
 } device_t;
 
+typedef enum device_option_type_s {
+  device_option_type_u8, // comp-type
+  device_option_type_u16, // comp-type
+  device_option_type_u32, // comp-type
+  device_option_type_bool,
+  device_option_type_integer,
+  device_option_type_integer64,
+  device_option_type_float,
+  device_option_type_string
+} device_option_type_t;
+
+#define MAX_DEVICE_OPTION_MENU 20
+
+typedef struct device_option_menu_s {
+  int id;
+  char name[64];
+} device_option_menu_t;
+
+typedef struct device_option_s {
+  char name[64];
+  unsigned int control_id;
+
+  device_option_type_t type;
+  int elems;
+  struct {
+    bool read_only : 1;
+    bool invalid : 1;
+  } flags;
+
+  device_option_menu_t menu[MAX_DEVICE_OPTION_MENU];
+  int menu_items;
+
+  char value[256];
+  char description[256];
+} device_option_t;
+
 device_t *device_open(const char *name, const char *path, device_hw_t *hw);
 void device_close(device_t *dev);
 
@@ -70,6 +110,7 @@ int device_set_stream(device_t *dev, bool do_on);
 int device_video_force_key(device_t *dev);
 
 void device_dump_options(device_t *dev, FILE *stream);
+int device_dump_options2(device_t *dev, device_option_fn fn, void *opaque);
 int device_set_fps(device_t *dev, int desired_fps);
 int device_set_rotation(device_t *dev, bool vflip, bool hflip);
 int device_set_target_crop(device_t *dev, const buffer_rect_t *rect);

--- a/device/device.h
+++ b/device/device.h
@@ -7,6 +7,7 @@
 typedef struct buffer_s buffer_t;
 typedef struct buffer_list_s buffer_list_t;
 typedef struct buffer_format_s buffer_format_t;
+typedef struct buffer_rect_s buffer_rect_t;
 typedef struct device_s device_t;
 struct pollfd;
 
@@ -18,6 +19,7 @@ typedef struct device_hw_s {
   int (*device_set_fps)(device_t *dev, int desired_fps);
   int (*device_set_rotation)(device_t *dev, bool vflip, bool hflip);
   int (*device_set_option)(device_t *dev, const char *key, const char *value);
+  int (*device_set_target_crop)(device_t *dev, const buffer_rect_t *rect);
 
   int (*buffer_open)(buffer_t *buf);
   void (*buffer_close)(buffer_t *buf);
@@ -70,6 +72,7 @@ int device_video_force_key(device_t *dev);
 void device_dump_options(device_t *dev, FILE *stream);
 int device_set_fps(device_t *dev, int desired_fps);
 int device_set_rotation(device_t *dev, bool vflip, bool hflip);
+int device_set_target_crop(device_t *dev, const buffer_rect_t *rect);
 int device_set_option_string(device_t *dev, const char *option, const char *value);
 void device_set_option_list(device_t *dev, const char *option_list);
 

--- a/device/libcamera/buffer.cc
+++ b/device/libcamera/buffer.cc
@@ -85,7 +85,7 @@ int libcamera_buffer_enqueue(buffer_t *buf, const char *who)
   if (camera->queueRequest(buf->libcamera->request.get()) < 0) {
     LOG_ERROR(buf, "Can't queue buffer.");
   }
-  buf->buf_list->dev->libcamera->controls.clear();
+  libcamera_device_apply_controls(buf->buf_list->dev);
   return 0;
 
 error:

--- a/device/libcamera/buffer_list.cc
+++ b/device/libcamera/buffer_list.cc
@@ -170,7 +170,7 @@ int libcamera_buffer_list_set_stream(buffer_list_t *buf_list, bool do_on)
       LOG_ERROR(buf_list, "Failed to start camera.");
     }
 
-    buf_list->dev->libcamera->controls.clear();
+    libcamera_device_apply_controls(buf_list->dev);
   } else {
     buf_list->dev->libcamera->camera->requestCompleted.disconnect(
       buf_list->libcamera, &buffer_list_libcamera_t::libcamera_buffer_list_dequeued);

--- a/device/libcamera/device.cc
+++ b/device/libcamera/device.cc
@@ -1,63 +1,6 @@
 #ifdef USE_LIBCAMERA
 #include "libcamera.hh"
 
-std::string libcamera_device_option_normalize(std::string key)
-{
-  key.resize(device_option_normalize_name(key.data(), key.data()));
-  return key;
-}
-
-libcamera::ControlInfoMap::Map libcamera_control_list(device_t *dev)
-{
-  libcamera::ControlInfoMap::Map controls_map;
-  for (auto const &control : dev->libcamera->camera->controls()) {
-    controls_map[control.first] = control.second;
-  }
-  return controls_map;
-}
-
-void libcamera_device_dump_options(device_t *dev, FILE *stream)
-{
-  auto &properties = dev->libcamera->camera->properties();
-  auto idMap = properties.idMap();
-
-  fprintf(stream, "%s Properties:\n", dev->name);
-
-  for (auto const &control : properties) {
-    if (!control.first)
-      continue;
-
-    auto control_id = control.first;
-    auto control_value = control.second;
-    std::string control_id_name = "";
-
-    if (auto control_id_info = idMap ? idMap->at(control_id) : NULL) {
-      control_id_name = control_id_info->name();
-    }
-
-    fprintf(stream, "- property: %s (%08x, type=%d): %s\n",
-      control_id_name.c_str(), control_id, control_value.type(),
-      control_value.toString().c_str());
-  }
-
-  fprintf(stream, "\n");
-  fprintf(stream, "%s Options:\n", dev->name);
-
-  for (auto const &control : libcamera_control_list(dev)) {
-    if (!control.first)
-      continue;
-
-    auto control_id = control.first;
-    auto control_key = libcamera_device_option_normalize(control_id->name());
-    auto control_info = control.second;
-
-    fprintf(stream, "- available option: %s (%08x, type=%d): %s\n",
-      control_id->name().c_str(), control_id->id(), control_id->type(),
-      control_info.toString().c_str());
-  }
-  fprintf(stream, "\n");
-}
-
 void libcamera_print_cameras(device_t *dev)
 {
   if (dev->libcamera->camera_manager->cameras().size()) {
@@ -153,99 +96,15 @@ int libcamera_device_set_rotation(device_t *dev, bool vflip, bool hflip)
   return 0;
 }
 
-int libcamera_device_set_option(device_t *dev, const char *keyp, const char *value)
+void libcamera_device_apply_controls(device_t *dev)
 {
-  auto key = libcamera_device_option_normalize(keyp);
+  auto &controls = dev->libcamera->controls;
+  auto &applied_controls = dev->libcamera->applied_controls;
 
-  for (auto const &control : libcamera_control_list(dev)) {
-    if (!control.first)
-      continue;
-
-    auto control_id = control.first;
-    auto control_key = libcamera_device_option_normalize(control_id->name());
-    if (key != control_key)
-      continue;
-
-    libcamera::ControlValue control_value;
-
-    switch (control_id->type()) {
-    case libcamera::ControlTypeNone:
-      break;
-
-    case libcamera::ControlTypeBool:
-      control_value.set<bool>(atoi(value));
-      break;
-
-    case libcamera::ControlTypeByte:
-      control_value.set<unsigned char>(atoi(value));
-      break;
-
-    case libcamera::ControlTypeInteger32:
-      control_value.set<int32_t>(atoi(value));
-      break;
-
-    case libcamera::ControlTypeInteger64:
-      control_value.set<int64_t>(atoi(value));
-      break;
-
-    case libcamera::ControlTypeFloat:
-      control_value.set<float>(atof(value));
-      break;
-
-    case libcamera::ControlTypeRectangle:
-      static const char *RECTANGLE_PATTERNS[] = {
-        "(%d,%d)/%ux%u",
-        "%d,%d,%u,%u",
-        NULL
-      };
-
-      for (int i = 0; RECTANGLE_PATTERNS[i]; i++) {
-        libcamera::Rectangle rectangle;
-      
-        if (4 == sscanf(value, RECTANGLE_PATTERNS[i],
-          &rectangle.x, &rectangle.y,
-          &rectangle.width, &rectangle.height)) {
-          control_value.set(rectangle);
-          break;
-        }
-      }
-      break;
-
-    case libcamera::ControlTypeSize:
-      static const char *SIZE_PATTERNS[] = {
-        "%ux%u",
-        "%u,%u",
-        NULL
-      };
-
-      for (int i = 0; SIZE_PATTERNS[i]; i++) {
-        libcamera::Size size;
-
-        if (2 == sscanf(value, SIZE_PATTERNS[i], &size.width, &size.height)) {
-          control_value.set(size);
-          break;
-        }
-      }
-      break;
-  
-    case libcamera::ControlTypeString:
-      break;
-    }
-
-    if (control_value.isNone()) {
-      LOG_ERROR(dev, "The `%s` type `%d` is not supported.", control_key.c_str(), control_id->type());
-    }
-
-    LOG_INFO(dev, "Configuring option %s (%08x, type=%d) = %s", 
-      control_key.c_str(), control_id->id(), control_id->type(),
-      control_value.toString().c_str());
-    dev->libcamera->controls.set(control_id->id(), control_value);
-    return 1;
+  for (auto &control : controls) {
+    applied_controls.set(control.first, control.second);
   }
 
-  return 0;
-
-error:
-  return -1;
+  controls.clear();
 }
 #endif // USE_LIBCAMERA

--- a/device/libcamera/libcamera.cc
+++ b/device/libcamera/libcamera.cc
@@ -5,6 +5,7 @@ device_hw_t libcamera_device_hw = {
   .device_open = libcamera_device_open,
   .device_close = libcamera_device_close,
   .device_dump_options = libcamera_device_dump_options,
+  .device_dump_options2 = libcamera_device_dump_options2,
   .device_set_fps = libcamera_device_set_fps,
   .device_set_rotation = libcamera_device_set_rotation,
   .device_set_option = libcamera_device_set_option,

--- a/device/libcamera/libcamera.hh
+++ b/device/libcamera/libcamera.hh
@@ -42,6 +42,7 @@ typedef struct device_libcamera_s {
   std::shared_ptr<libcamera::CameraConfiguration> configuration;
   std::shared_ptr<libcamera::FrameBufferAllocator> allocator;
   libcamera::ControlList controls;
+  libcamera::ControlList applied_controls;
   bool vflip, hflip;
 } device_libcamera_t;
 
@@ -59,9 +60,11 @@ typedef struct buffer_libcamera_s {
 int libcamera_device_open(device_t *dev);
 void libcamera_device_close(device_t *dev);
 void libcamera_device_dump_options(device_t *dev, FILE *stream);
+int libcamera_device_dump_options2(device_t *dev, device_option_fn fn, void *opaque);
 int libcamera_device_set_fps(device_t *dev, int desired_fps);
 int libcamera_device_set_rotation(device_t *dev, bool vflip, bool hflip);
 int libcamera_device_set_option(device_t *dev, const char *key, const char *value);
+void libcamera_device_apply_controls(device_t *dev);
 
 int libcamera_buffer_open(buffer_t *buf);
 void libcamera_buffer_close(buffer_t *buf);

--- a/device/libcamera/options.cc
+++ b/device/libcamera/options.cc
@@ -60,6 +60,11 @@ static std::map<unsigned, libcamera_control_id_t> libcamera_control_ids =
   LIBCAMERA_DRAFT_CONTROL(TestPatternMode)
 };
 
+static std::set<const libcamera::ControlId *> ignored_controls =
+{
+  &libcamera::controls::FrameDurationLimits
+};
+
 static auto control_type_values = control_enum_values<libcamera::ControlType>("ControlType");
 
 static const std::map<unsigned, std::string> *libcamera_find_control_ids(unsigned control_id)
@@ -151,6 +156,10 @@ void libcamera_device_dump_options(device_t *dev, FILE *stream)
 
 static int libcamera_device_dump_control_option(device_option_fn fn, void *opaque, const libcamera::ControlId &control_id, const libcamera::ControlInfo *control_info, const libcamera::ControlValue *control_value, bool read_only)
 {
+  if (ignored_controls.find(&control_id) != ignored_controls.end()) {
+    return 0;
+  }
+
   device_option_t opt = {
     .control_id = control_id.id()
   };

--- a/device/libcamera/options.cc
+++ b/device/libcamera/options.cc
@@ -1,0 +1,446 @@
+#ifdef USE_LIBCAMERA
+#include "libcamera.hh"
+#include "third_party/magic_enum/include/magic_enum.hpp"
+
+static std::string libcamera_device_option_normalize(std::string key)
+{
+  key.resize(device_option_normalize_name(key.data(), key.data()));
+  return key;
+}
+
+template<typename T>
+static std::map<unsigned, std::string> control_enum_values(const char *prefix)
+{
+  std::map<unsigned, std::string> ret;
+
+  for (auto e : magic_enum::enum_entries<T>()) {
+    auto value = std::string(e.second);
+    if (prefix && value.find(prefix) == 0) {
+      value = value.substr(strlen(prefix));
+    }
+    ret[e.first] = value;
+  }
+
+  return ret;
+}
+
+struct libcamera_control_id_t
+{
+  const libcamera::ControlId *control_id;
+  std::map<unsigned, std::string> enum_values;
+};
+
+#define LIBCAMERA_CONTROL_RAW(Name, Strip) \
+  { Name.id(), { .control_id = &Name, .enum_values = control_enum_values<Name##Enum>(Strip), } }
+
+#define LIBCAMERA_CONTROL(Name, Strip) \
+  LIBCAMERA_CONTROL_RAW(libcamera::controls::Name, Strip ? Strip : #Name)
+
+#define LIBCAMERA_DRAFT_CONTROL(Name) \
+  LIBCAMERA_CONTROL_RAW(libcamera::controls::draft::Name, #Name)
+
+static std::map<unsigned, libcamera_control_id_t> libcamera_control_ids =
+{
+  LIBCAMERA_CONTROL(AeMeteringMode, "Metering"),
+  LIBCAMERA_CONTROL(AeConstraintMode, "Constraint"),
+  LIBCAMERA_CONTROL(AeExposureMode, "Exposure"),
+  LIBCAMERA_CONTROL(AwbMode, "Awb"),
+  LIBCAMERA_CONTROL(AfMode, "AfMode"),
+  LIBCAMERA_CONTROL(AfRange, "AfRange"),
+  LIBCAMERA_CONTROL(AfSpeed, "AfSpeed"),
+  LIBCAMERA_CONTROL(AfTrigger, "AfTrigger"),
+  LIBCAMERA_CONTROL(AfState, "AfState"),
+  LIBCAMERA_DRAFT_CONTROL(AePrecaptureTrigger),
+  LIBCAMERA_DRAFT_CONTROL(NoiseReductionMode),
+  LIBCAMERA_DRAFT_CONTROL(ColorCorrectionAberrationMode),
+  LIBCAMERA_DRAFT_CONTROL(AeState),
+  LIBCAMERA_DRAFT_CONTROL(AwbState),
+  LIBCAMERA_DRAFT_CONTROL(LensShadingMapMode),
+  LIBCAMERA_DRAFT_CONTROL(SceneFlicker),
+  LIBCAMERA_DRAFT_CONTROL(TestPatternMode)
+};
+
+static auto control_type_values = control_enum_values<libcamera::ControlType>("ControlType");
+
+static const std::map<unsigned, std::string> *libcamera_find_control_ids(unsigned control_id)
+{
+  auto iter = libcamera_control_ids.find(control_id);
+  if (iter == libcamera_control_ids.end())
+    return NULL;
+
+  return &iter->second.enum_values;
+}
+
+static long long libcamera_find_control_id_named_value(unsigned control_id, const char *name)
+{
+  auto named_values = libcamera_find_control_ids(control_id);
+  if (named_values) {
+    for (const auto & named_value : *named_values) {
+      if (device_option_is_equal(named_value.second.c_str(), name))
+        return named_value.first;
+    }
+  }
+
+  return strtoll(name, NULL, 10);
+}
+
+static libcamera::ControlInfoMap::Map libcamera_control_list(device_t *dev)
+{
+  libcamera::ControlInfoMap::Map controls_map;
+  for (auto const &control : dev->libcamera->camera->controls()) {
+    controls_map[control.first] = control.second;
+  }
+  return controls_map;
+}
+
+void libcamera_device_dump_options(device_t *dev, FILE *stream)
+{
+  auto &properties = dev->libcamera->camera->properties();
+  auto idMap = properties.idMap();
+
+  fprintf(stream, "%s Properties:\n", dev->name);
+
+  for (auto const &control : properties) {
+    if (!control.first)
+      continue;
+
+    auto control_id = control.first;
+    auto control_value = control.second;
+    std::string control_id_name = "";
+
+    if (auto control_id_info = idMap ? idMap->at(control_id) : NULL) {
+      control_id_name = control_id_info->name();
+    }
+
+    fprintf(stream, "- property: %s (%08x, type=%s) = %s\n",
+      control_id_name.c_str(), control_id,
+      control_type_values[control_value.type()].c_str(),
+      control_value.toString().c_str());
+  }
+
+  fprintf(stream, "\n");
+  fprintf(stream, "%s Options:\n", dev->name);
+
+  for (auto const &control : libcamera_control_list(dev)) {
+    if (!control.first)
+      continue;
+
+    auto control_id = control.first;
+    auto control_key = libcamera_device_option_normalize(control_id->name());
+    auto control_info = control.second;
+
+    fprintf(stream, "- available option: %s (%08x, type=%s): %s\n",
+      control_id->name().c_str(), control_id->id(),
+      control_type_values[control_id->type()].c_str(),
+      control_info.toString().c_str());
+
+    auto named_values = libcamera_find_control_ids(control_id->id());
+
+    if (named_values != NULL) {
+      for (const auto & named_value : *named_values) {
+        fprintf(stream, "\t\t%d: %s\n", named_value.first, named_value.second.c_str());
+      }
+    } else {
+      for (size_t i = 0; i < control_info.values().size(); i++) {
+        fprintf(stream, "\t\t%s\n", control_info.values()[i].toString().c_str());
+      }
+    }
+  }
+  fprintf(stream, "\n");
+}
+
+static int libcamera_device_dump_control_option(device_option_fn fn, void *opaque, const libcamera::ControlId &control_id, const libcamera::ControlInfo *control_info, const libcamera::ControlValue *control_value, bool read_only)
+{
+  device_option_t opt = {
+    .control_id = control_id.id()
+  };
+  opt.flags.read_only = read_only;
+  strcpy(opt.name, control_id.name().c_str());
+
+  if (control_info) {
+    strcpy(opt.description, control_info->toString().c_str());
+  }
+
+  if (control_value) {
+    if (!control_value->isNone()) {
+      strcpy(opt.value, control_value->toString().c_str());
+    } else {
+      control_value = NULL;
+    }
+  }
+
+  switch (control_id.type()) {
+  case libcamera::ControlTypeNone:
+    break;
+
+  case libcamera::ControlTypeBool:
+    opt.type = device_option_type_bool;
+    break;
+
+  case libcamera::ControlTypeByte:
+    opt.type = device_option_type_u8;
+    break;
+
+  case libcamera::ControlTypeInteger32:
+    opt.type = device_option_type_integer;
+    break;
+
+  case libcamera::ControlTypeInteger64:
+    opt.type = device_option_type_integer64;
+    break;
+
+  case libcamera::ControlTypeFloat:
+    opt.type = device_option_type_float;
+    break;
+
+  case libcamera::ControlTypeRectangle:
+    opt.type = device_option_type_float;
+    opt.elems = 4;
+    break;
+
+  case libcamera::ControlTypeSize:
+    opt.type = device_option_type_float;
+    opt.elems = 2;
+    break;
+
+  case libcamera::ControlTypeString:
+    opt.type = device_option_type_string;
+    break;
+  }
+
+  auto named_values = libcamera_find_control_ids(control_id.id());
+
+  if (named_values != NULL) {
+    for (const auto & named_value : *named_values) {
+      if (opt.menu_items >= MAX_DEVICE_OPTION_MENU) {
+        opt.flags.invalid = true;
+        break;
+      }
+
+      device_option_menu_t *opt_menu = &opt.menu[opt.menu_items++];
+      opt_menu->id = named_value.first;
+      strcpy(opt_menu->name, named_value.second.c_str());
+      if (control_value && atoi(control_value->toString().c_str()) == opt_menu->id) {
+        strcpy(opt.value, opt_menu->name);
+      }
+    }
+  } else if (control_info) {
+    for (size_t i = 0; i < control_info->values().size(); i++) {
+      if (opt.menu_items >= MAX_DEVICE_OPTION_MENU) {
+        opt.flags.invalid = true;
+        break;
+      }
+
+      device_option_menu_t *opt_menu = &opt.menu[opt.menu_items++];
+      opt_menu->id = atoi(control_info->values()[i].toString().c_str());
+      strcpy(opt_menu->name, control_info->values()[i].toString().c_str());
+      if (control_value && atoi(control_value->toString().c_str()) == opt_menu->id) {
+        strcpy(opt.value, opt_menu->name);
+      }
+    }
+  } else if (control_value && control_value->numElements() > 0) {
+    opt.elems = control_value->numElements();
+  }
+
+  if (opt.type) {
+    int ret = fn(&opt, opaque);
+    if (ret < 0)
+      return ret;
+  }
+
+  return 0;
+}
+
+int libcamera_device_dump_options2(device_t *dev, device_option_fn fn, void *opaque)
+{
+  auto &properties = dev->libcamera->camera->properties();
+  auto idMap = properties.idMap();
+
+  int n = 0;
+
+  for (auto const &control : properties) {
+    if (!control.first)
+      continue;
+
+    auto control_id = control.first;
+    auto control_value = control.second;
+    std::string control_id_name = "";
+
+    if (auto control_id_info = idMap ? idMap->at(control_id) : NULL) {
+      int ret = libcamera_device_dump_control_option(fn, opaque, *control_id_info, NULL, &control_value, true);
+      if (ret < 0)
+        return ret;
+
+      n++;
+    }
+  }
+
+  for (auto const &control : libcamera_control_list(dev)) {
+    if (!control.first)
+      continue;
+
+    auto control_id = control.first;
+    auto control_info = control.second;
+
+    auto control_value = dev->libcamera->applied_controls.contains(control_id->id())
+      ? &dev->libcamera->applied_controls.get(control_id->id())
+      : nullptr;
+
+    int ret = libcamera_device_dump_control_option(fn, opaque,
+      *control_id, &control_info, control_value, false);
+    if (ret < 0)
+      return ret;
+    n++;
+  }
+
+  return n;
+}
+
+static libcamera::Rectangle libcamera_parse_rectangle(const char *value)
+{
+  static const char *RECTANGLE_PATTERNS[] =
+  {
+    "(%d,%d)/%ux%u",
+    "%d,%d,%u,%u",
+    NULL
+  };
+
+  for (int i = 0; RECTANGLE_PATTERNS[i]; i++) {
+    libcamera::Rectangle rectangle;
+
+    if (4 == sscanf(value, RECTANGLE_PATTERNS[i],
+      &rectangle.x, &rectangle.y,
+      &rectangle.width, &rectangle.height)) {
+      return rectangle;
+    }
+  }
+
+  return libcamera::Rectangle();
+}
+
+static libcamera::Size libcamera_parse_size(const char *value)
+{
+  static const char *SIZE_PATTERNS[] =
+  {
+    "%ux%u",
+    "%u,%u",
+    NULL
+  };
+
+  for (int i = 0; SIZE_PATTERNS[i]; i++) {
+    libcamera::Size size;
+
+    if (2 == sscanf(value, SIZE_PATTERNS[i], &size.width, &size.height)) {
+      return size;
+    }
+  }
+
+  return libcamera::Size();
+}
+
+template<typename T, typename F>
+static bool libcamera_parse_control_value(libcamera::ControlValue &control_value, const char *value, const F &fn)
+{
+  std::vector<T> parsed;
+
+  while (value && *value) {
+    std::string current_value;
+
+    if (const char *next = strchr(value, ',')) {
+      current_value.assign(value, next);
+      value = &next[1];
+    } else {
+      current_value.assign(value);
+      value = NULL;
+    }
+
+    if (current_value.empty())
+      continue;
+
+    parsed.push_back(fn(current_value.c_str()));
+  }
+
+  if (parsed.empty()) {
+    return false;
+  }
+
+  if (parsed.size() > 1) {
+    control_value.set<libcamera::Span<T> >(parsed);
+  } else {
+    control_value.set<T>(parsed[0]);
+  }
+
+  return true;
+}
+
+int libcamera_device_set_option(device_t *dev, const char *keyp, const char *value)
+{
+  for (auto const &control : libcamera_control_list(dev)) {
+    if (!control.first)
+      continue;
+
+    auto control_id = control.first;
+    auto control_key = control_id->name();
+    if (!device_option_is_equal(keyp, control_key.c_str()))
+      continue;
+
+    libcamera::ControlValue control_value;
+
+    switch (control_id->type()) {
+    case libcamera::ControlTypeNone:
+      break;
+
+    case libcamera::ControlTypeBool:
+      control_value.set<bool>(atoi(value));
+      break;
+
+    case libcamera::ControlTypeByte:
+      libcamera_parse_control_value<unsigned char>(control_value, value,
+        [control_id](const char *value) { return libcamera_find_control_id_named_value(control_id->id(), value); });
+      break;
+
+    case libcamera::ControlTypeInteger32:
+      libcamera_parse_control_value<int32_t>(control_value, value,
+        [control_id](const char *value) { return libcamera_find_control_id_named_value(control_id->id(), value); });
+      break;
+
+    case libcamera::ControlTypeInteger64:
+      libcamera_parse_control_value<int64_t>(control_value, value,
+        [control_id](const char *value) { return libcamera_find_control_id_named_value(control_id->id(), value); });
+      break;
+
+    case libcamera::ControlTypeFloat:
+      libcamera_parse_control_value<float>(control_value, value, atof);
+      break;
+
+    case libcamera::ControlTypeRectangle:
+      libcamera_parse_control_value<libcamera::Rectangle>(
+        control_value, value, libcamera_parse_rectangle);
+      break;
+
+    case libcamera::ControlTypeSize:
+      libcamera_parse_control_value<libcamera::Size>(
+        control_value, value, libcamera_parse_size);
+      break;
+
+    case libcamera::ControlTypeString:
+      break;
+    }
+
+    if (control_value.isNone()) {
+      LOG_ERROR(dev, "The `%s` type `%d` is not supported.", control_key.c_str(), control_id->type());
+    }
+
+    LOG_INFO(dev, "Configuring option '%s' (%08x, type=%d) = %s", 
+      control_key.c_str(), control_id->id(), control_id->type(),
+      control_value.toString().c_str());
+    dev->libcamera->controls.set(control_id->id(), control_value);
+    return 1;
+  }
+
+  return 0;
+
+error:
+  return -1;
+}
+#endif // USE_LIBCAMERA

--- a/device/v4l2/device.c
+++ b/device/v4l2/device.c
@@ -1,4 +1,5 @@
 #include "v4l2.h"
+#include "device/buffer_list.h"
 #include "device/device.h"
 #include "util/opts/log.h"
 
@@ -76,6 +77,33 @@ int v4l2_device_set_fps(device_t *dev, int desired_fps)
   LOG_DEBUG(dev, "Configuring FPS ...");
   ERR_IOCTL(dev, dev->v4l2->dev_fd, VIDIOC_S_PARM, &setfps, "Can't set FPS");
   return 0;
+error:
+  return -1;
+}
+
+int v4l2_device_set_target_crop(device_t *dev, const buffer_rect_t *rect)
+{
+  if (!dev->v4l2)
+    return -1;
+
+  struct v4l2_rect v4l2_rect = {
+    .left = rect->x,
+    .top = rect->y,
+    .width = rect->width,
+    .height = rect->height
+  };
+
+	struct v4l2_selection v4l2_sel = {
+    .type = V4L2_BUF_TYPE_VIDEO_OUTPUT,
+    .target = V4L2_SEL_TGT_CROP,
+    .flags = 0,
+    .r = v4l2_rect
+  };
+
+  ERR_IOCTL(dev, dev->v4l2->dev_fd, VIDIOC_S_SELECTION, &v4l2_sel, "Can't set target crop selection");
+
+  return 0;
+
 error:
   return -1;
 }

--- a/device/v4l2/v4l2.c
+++ b/device/v4l2/v4l2.c
@@ -6,6 +6,7 @@ device_hw_t v4l2_device_hw = {
   .device_close = v4l2_device_close,
   .device_video_force_key = v4l2_device_video_force_key,
   .device_dump_options = v4l2_device_dump_options,
+  .device_dump_options2 = v4l2_device_dump_options2,
   .device_set_fps = v4l2_device_set_fps,
   .device_set_option = v4l2_device_set_option,
   .device_set_target_crop = v4l2_device_set_target_crop,

--- a/device/v4l2/v4l2.c
+++ b/device/v4l2/v4l2.c
@@ -8,6 +8,7 @@ device_hw_t v4l2_device_hw = {
   .device_dump_options = v4l2_device_dump_options,
   .device_set_fps = v4l2_device_set_fps,
   .device_set_option = v4l2_device_set_option,
+  .device_set_target_crop = v4l2_device_set_target_crop,
 
   .buffer_open = v4l2_buffer_open,
   .buffer_close = v4l2_buffer_close,

--- a/device/v4l2/v4l2.h
+++ b/device/v4l2/v4l2.h
@@ -9,6 +9,7 @@
 
 typedef struct buffer_s buffer_t;
 typedef struct buffer_list_s buffer_list_t;
+typedef struct buffer_rect_s buffer_rect_t;
 typedef struct device_s device_t;
 struct pollfd;
 
@@ -40,6 +41,7 @@ int v4l2_device_video_force_key(device_t *dev);
 void v4l2_device_dump_options(device_t *dev, FILE *stream);
 int v4l2_device_set_fps(device_t *dev, int desired_fps);
 int v4l2_device_set_option(device_t *dev, const char *key, const char *value);
+int v4l2_device_set_target_crop(device_t *dev, const buffer_rect_t *rect);
 
 int v4l2_buffer_open(buffer_t *buf);
 void v4l2_buffer_close(buffer_t *buf);

--- a/device/v4l2/v4l2.h
+++ b/device/v4l2/v4l2.h
@@ -10,8 +10,11 @@
 typedef struct buffer_s buffer_t;
 typedef struct buffer_list_s buffer_list_t;
 typedef struct buffer_rect_s buffer_rect_t;
+typedef struct device_option_s device_option_t;
 typedef struct device_s device_t;
 struct pollfd;
+
+typedef int device_option_fn(device_option_t *option, void *opaque);
 
 typedef struct device_v4l2_control_s {
   int fd;
@@ -39,6 +42,7 @@ int v4l2_device_open(device_t *dev);
 void v4l2_device_close(device_t *dev);
 int v4l2_device_video_force_key(device_t *dev);
 void v4l2_device_dump_options(device_t *dev, FILE *stream);
+int v4l2_device_dump_options2(device_t *dev, device_option_fn fn, void *opaque);
 int v4l2_device_set_fps(device_t *dev, int desired_fps);
 int v4l2_device_set_option(device_t *dev, const char *key, const char *value);
 int v4l2_device_set_target_crop(device_t *dev, const buffer_rect_t *rect);

--- a/html/control.html
+++ b/html/control.html
@@ -1,0 +1,819 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Camera Streamer Web Control</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <style>
+      body {
+        font-family: Arial,Helvetica,sans-serif;
+        background: #181818;
+        color: #EFEFEF;
+        font-size: 16px
+      }
+
+      a {
+        color: #EFEFEF;
+        text-decoration: underline
+      }
+
+      h2 {
+        font-size: 18px
+      }
+
+      section.main {
+        display: flex
+      }
+
+      #menu,section.main {
+        flex-direction: column
+      }
+
+      #menu {
+        display: none;
+        flex-wrap: nowrap;
+        color: #EFEFEF;
+        width: 380px;
+        background: #363636;
+        padding: 8px;
+        border-radius: 4px;
+        margin-top: -6px;
+        margin-right: 10px;
+      }
+
+      /*     #content {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: stretch
+      }
+      */
+      figure {
+        padding: 0px;
+        margin: 0;
+        margin-block-start: 0;
+        margin-block-end: 0;
+        margin-inline-start: 0;
+        margin-inline-end: 0
+      }
+
+      figure img {
+        display: block;
+        max-width: 100%;
+        width: auto;
+        height: auto;
+        border-radius: 4px;
+      }
+
+      figure video {
+        display: block;
+        max-width: 100%;
+        width: auto;
+        height: auto;
+        border-radius: 4px;
+      }
+
+      section#buttons {
+        display: flex;
+        flex-wrap: nowrap;
+        justify-content: space-between
+      }
+
+      #logo {
+        margin-bottom: 10px;
+      }
+
+      #nav-toggle {
+        cursor: pointer;
+        display: block;
+        margin: 3px;
+        line-height: 28px;
+      }
+
+      #nav-toggle-cb {
+        outline: 0;
+        opacity: 0;
+        width: 0;
+        height: 0
+      }
+
+      #nav-toggle-cb:checked+#menu {
+        display: flex
+      }
+
+      #quality {
+          transform: rotateY(180deg);
+      }
+
+      .input-group {
+        display: flex;
+        flex-wrap: nowrap;
+        line-height: 22px;
+        margin: 5px 0
+      }
+
+      .input-group>label {
+        display: inline-block;
+        padding-right: 10px;
+        min-width: 47%
+      }
+
+      .input-group input,.input-group select {
+        flex-grow: 1
+      }
+
+      .input-group>a {
+        word-break: break-all
+      }
+
+      .range-max,.range-min {
+        display: inline-block;
+        padding: 0 5px
+      }
+
+      button {
+        display: block;
+        margin: 3px;
+        padding: 0 8px;
+        border: 0;
+        line-height: 28px;
+        cursor: pointer;
+        color: #fff;
+        background: #ff3034;
+        border-radius: 5px;
+        font-size: 16px;
+        outline: 0
+      }
+
+      button:hover {
+        background: #ff494d
+      }
+
+      button:active {
+        background: #f21c21
+      }
+
+      button.disabled {
+        cursor: default;
+        background: #a0a0a0
+      }
+
+      input[type=range] {
+        -webkit-appearance: none;
+        width: 0;
+        height: 22px;
+        background: #363636;
+        cursor: pointer;
+        margin: 0
+      }
+
+      input[type=range]:focus {
+        outline: 0
+      }
+
+      input[type=range]::-webkit-slider-runnable-track {
+        width: 100%;
+        height: 2px;
+        cursor: pointer;
+        background: #EFEFEF;
+        border-radius: 0;
+        border: 0 solid #EFEFEF
+      }
+
+      input[type=range]::-webkit-slider-thumb {
+        border: 1px solid rgba(0,0,30,0);
+        height: 22px;
+        width: 22px;
+        border-radius: 50px;
+        background: #ff3034;
+        cursor: pointer;
+        -webkit-appearance: none;
+        margin-top: -11.5px
+      }
+
+      input[type=range]:focus::-webkit-slider-runnable-track {
+        background: #EFEFEF
+      }
+
+      input[type=range]::-moz-range-track {
+        width: 100%;
+        height: 2px;
+        cursor: pointer;
+        background: #EFEFEF;
+        border-radius: 0;
+        border: 0 solid #EFEFEF
+      }
+
+      input[type=range]::-moz-range-thumb {
+        border: 1px solid rgba(0,0,30,0);
+        height: 22px;
+        width: 22px;
+        border-radius: 50px;
+        background: #ff3034;
+        cursor: pointer
+      }
+
+      input[type=range]::-ms-track {
+        width: 100%;
+        height: 2px;
+        cursor: pointer;
+        background: 0 0;
+        border-color: transparent;
+        color: transparent
+      }
+
+      input[type=range]::-ms-fill-lower {
+        background: #EFEFEF;
+        border: 0 solid #EFEFEF;
+        border-radius: 0
+      }
+
+      input[type=range]::-ms-fill-upper {
+        background: #EFEFEF;
+        border: 0 solid #EFEFEF;
+        border-radius: 0
+      }
+
+      input[type=range]::-ms-thumb {
+        border: 1px solid rgba(0,0,30,0);
+        height: 22px;
+        width: 22px;
+        border-radius: 50px;
+        background: #ff3034;
+        cursor: pointer;
+        height: 2px
+      }
+
+      input[type=range]:focus::-ms-fill-lower {
+        background: #EFEFEF
+      }
+
+      input[type=range]:focus::-ms-fill-upper {
+        background: #363636
+      }
+
+      input[type=text] {
+        border: 1px solid #363636;
+        font-size: 14px;
+        height: 20px;
+        margin: 1px;
+        outline: 0;
+        border-radius: 5px
+      }
+
+      .switch {
+        display: block;
+        position: relative;
+        line-height: 22px;
+        font-size: 16px;
+        height: 22px
+      }
+
+      .switch input {
+        outline: 0;
+        opacity: 0;
+        width: 0;
+        height: 0
+      }
+
+      .slider {
+        width: 50px;
+        height: 22px;
+        border-radius: 22px;
+        cursor: pointer;
+        background-color: grey
+      }
+
+      .slider,.slider:before {
+        display: inline-block;
+        transition: .4s
+      }
+
+      .slider:before {
+        position: relative;
+        content: "";
+        border-radius: 50%;
+        height: 16px;
+        width: 16px;
+        left: 4px;
+        top: 3px;
+        background-color: #fff
+      }
+
+      input:checked+.slider {
+        background-color: #ff3034
+      }
+
+      input:checked+.slider:before {
+        -webkit-transform: translateX(26px);
+        transform: translateX(26px)
+      }
+
+      select {
+        border: 1px solid #363636;
+        font-size: 14px;
+        height: 22px;
+        outline: 0;
+        border-radius: 5px
+      }
+
+      .image-container {
+        position: fixed;
+        min-width: 160px;
+        margin-right: 16px;
+        transform-origin: top left;
+      }
+
+      .close {
+        position: absolute;
+        z-index: 99;
+        background: #ff3034;
+        width: 16px;
+        height: 16px;
+        border-radius: 100px;
+        color: #fff;
+        text-align: center;
+        line-height: 18px;
+        cursor: pointer
+      }
+
+      .close-rot-none {
+        left: 5px;
+        top: 5px;
+      }
+
+      .close-rot-left {
+        right: 5px;
+        top: 5px;
+      }
+
+      .close-rot-right {
+        left: 5px;
+        bottom: 5px;
+      }
+
+      .hidden {
+        display: none
+      }
+
+      .inline-button {
+        line-height: 20px;
+        margin: 2px;
+        padding: 1px 4px 2px 4px;
+      }
+
+      .loader {
+        border: 0.5em solid #f3f3f3; /* Light grey */
+        border-top: 0.5em solid #000000; /* white */
+        border-radius: 50%;
+        width: 1em;
+        height: 1em;
+        -webkit-animation: spin 2s linear infinite; /* Safari */
+        animation: spin 2s linear infinite;
+      }
+
+      @-webkit-keyframes spin {   /* Safari */
+        0% { -webkit-transform: rotate(0deg); }
+        100% { -webkit-transform: rotate(360deg); }
+      }
+
+      @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+      }
+
+      @media (min-width: 800px) and (orientation:landscape) {
+        #content {
+          display:flex;
+          flex-wrap: nowrap;
+          align-items: stretch
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <section class="main">
+      <div id="logo">
+        <label for="nav-toggle-cb" id="nav-toggle" style="float:left;">&#9776;&nbsp;&nbsp;Settings&nbsp;&nbsp;&nbsp;&nbsp;</label>
+        <button id="get-still" style="float:left;" disabled>Get Still</button>
+        <button id="mjpeg-stream" style="float:left;" disabled>Start MJPEG</button>
+        <button id="webrtc-stream" style="float:left;" disabled>Start WebRTC</button>
+        <div id="wait-settings" style="float:left;" class="loader" title="Waiting for camera settings to load"></div>
+      </div>
+      <div id="content">
+        <div class="hidden" id="sidebar">
+          <input type="checkbox" id="nav-toggle-cb" checked="checked">
+            <nav id="menu">
+              <!-- <h1>Preferences</h1>
+              <div class="input-group" id="preferences-group">
+                <button id="reboot" title="Reboot the camera module">Reboot</button>
+                <button id="save_prefs" title="Save Preferences on camera module">Save</button>
+                <button id="clear_prefs" title="Erase saved Preferences on camera module">Erase</button>
+              </div> -->
+
+              <h1>Experimental</h1>
+              <ul>
+                <li>Changes are not persisted.</li>
+                <li>Use <i>--camera-options</i> to persist CAMERA settings.</li>
+                <li>Use <i>--camera-snapshot.options</i> to persist SNAPSHOT settings.</li>
+                <li>Use <i>--camera-stream.options</i> to persist STREAM settings.</li>
+                <li>Use <i>--camera-video.options</i> to persist VIDEO settings.</li>
+                <li>Restart the <b>camera-streamer</b> service to reset.</li>
+                <li>Some options might crash the process.</li>
+              </ul>
+
+              <h1 id="anchor">Links</h1>
+              <div class="input-group hidden" id="snapshot-group">
+                <label for="snapshot_url">Snapshot</label>
+                <a id="snapshot_url" class="default-action">Unknown</a>
+              </div>
+              <div class="input-group hidden" id="stream-group">
+                <label for="stream_url">Stream</label>
+                <a id="stream_url" class="default-action">Unknown</a>
+              </div>
+              <div class="input-group hidden" id="video-group">
+                <label for="video_url">Video</label>
+                <a id="video_url" class="default-action">Unknown</a>
+              </div>
+              <div class="input-group hidden" id="webrtc-group">
+                <label for="webrtc_url">WebRTC</label>
+                <a id="webrtc_url" class="default-action">Unknown</a>
+              </div>
+              <div class="input-group hidden" id="rtsp-group">
+                <label for="rtsp_url">RTSP</label>
+                <a id="rtsp_url" class="default-action">Unknown</a>
+              </div>
+
+              <h1>Release</h1>
+              <div class="input-group">
+                <label for="git_version">Version</label>
+                <div id="git_version" class="default-action">Unknown</div>
+              </div>
+              <div class="input-group">
+                <label for="git_revision">Stream</label>
+                <div id="git_revision" class="default-action">Unknown</div>
+              </div>
+            </nav>
+        </div>
+        <figure>
+          <div id="stream-container" class="image-container hidden">
+            <div class="close close-rot-none" click="stopStream()">×</div>
+            <img id="stream-view" src="">
+          </div>
+          <div id="video-container" class="image-container hidden">
+            <div class="close close-rot-none" click="stopStream()">×</div>
+            <video id="video-view" controls autoplay muted playsinline src="">
+          </div>
+        </figure>
+      </div>
+    </section>
+  </body>
+
+  <script>
+  document.addEventListener('DOMContentLoaded', function (event) {
+    var streamURL = 'Undefined';
+    var snapshotURL = 'Undefined';
+    var webrtcURL = 'Undefined';
+
+    const header = document.getElementById('logo')
+    const settings = document.getElementById('sidebar')
+    const waitSettings = document.getElementById('wait-settings')
+
+    const hide = el => {
+      el.classList.add('hidden')
+    }
+    const show = el => {
+      el.classList.remove('hidden')
+    }
+    const show2 = (el, status) => {
+      if (status)
+        show(el);
+      else
+        hide(el);
+    }
+
+    const enable = el => {
+      el.classList.remove('disabled')
+      el.disabled = false
+    }
+    const disable = el => {
+      el.classList.add('disabled')
+      el.disabled = true
+    }
+    const enable2 = (el, status) => {
+      if (status)
+        enable(el);
+      else
+        disable(el);
+    }
+
+    document
+      .querySelectorAll('.close')
+      .forEach(el => {
+        el.onclick = () => {
+          hide(el.parentNode)
+        }
+      })
+
+    const configureEndpoints =(state) => {
+      snapshotURL = state.endpoints.snapshot.uri;
+      streamURL = state.endpoints.stream.uri;
+      webrtcURL = state.endpoints.webrtc.uri;
+
+      enable2(document.getElementById('get-still'), state.endpoints.snapshot.enabled);
+      enable2(document.getElementById('mjpeg-stream'), state.endpoints.stream.enabled);
+      enable2(document.getElementById('webrtc-stream'), state.endpoints.webrtc.enabled);
+
+      document.getElementById('git_version').textContent = state.version;
+      document.getElementById('git_revision').textContent = state.revision;
+
+      for (let type of ["snapshot", "stream", "video", "webrtc", "rtsp"]) {
+        if (!state.endpoints[type].enabled)
+          continue;
+        let groupView = document.getElementById(`${type}-group`);
+        let urlView = document.getElementById(`${type}_url`);
+        show(groupView);
+        urlView.href = urlView.innerHTML = state.endpoints[type].uri;
+      }
+    };
+    
+    const sendOptionValue = (device, key, value) => {
+      device = encodeURIComponent(device);
+      key = encodeURIComponent(key);
+      value = encodeURIComponent(value);
+
+      return fetch(`option?device=${device}&key=${key}&value=${value}`, {
+        method: 'POST'
+      }).then(function (response) {
+        return response
+      });
+    };
+
+    const insertControl = (type) => {
+      const node = document.createElement(type);
+      const preferences = document.getElementById("anchor");
+      preferences.parentNode.insertBefore(node, preferences);
+      return node;
+    }
+
+    const createDeviceOption = (device, key, option) => {
+      const id_key = `${device}_${key}`;
+      const groupEl = insertControl("div");
+      groupEl.className = "input-group";
+
+      const labelEl = document.createElement("label");
+      labelEl.setAttribute("for", id_key);
+      labelEl.textContent = option.name;
+      groupEl.appendChild(labelEl);
+
+      switch (option.type) {
+        case "bool":
+          const divEl = document.createElement("div");
+          divEl.className = "switch";
+          groupEl.appendChild(divEl);
+
+          const inputEl = document.createElement("input");
+          inputEl.id = id_key;
+          inputEl.type = "checkbox";
+          inputEl.className = "default-action";
+          divEl.appendChild(inputEl);
+
+          const labelSliderEl = document.createElement("label");
+          labelSliderEl.setAttribute("for", id_key);
+          labelSliderEl.className = "slider";
+          divEl.appendChild(labelSliderEl);
+
+          if (option.value)
+            inputEl.checked = option.value == '1';
+          inputEl.onclick = () => {
+            sendOptionValue(device.name, key, inputEl.checked ? 1 : 0);
+          }
+          break;
+
+        case "integer":
+        case "integer64":
+        case "float":
+          if (option.menu) {
+            const selectEl = document.createElement("select");
+            selectEl.className = "default-action";
+            selectEl.id = id_key;
+            selectEl.value = option.value;
+            groupEl.appendChild(selectEl);
+
+            if (!option.value) {
+              const optionEl = document.createElement("option");
+              optionEl.text = "?";
+              selectEl.add(optionEl);
+            }
+
+            for (var value in option.menu) {
+              const optionEl = document.createElement("option");
+              optionEl.value = value;
+              optionEl.text = option.menu[value];
+              selectEl.add(optionEl);
+
+              if (optionEl.text == option.value)
+                selectEl.value = value;
+            }
+            selectEl.onchange = () => {
+              sendOptionValue(device.name, key, selectEl.value);
+            }
+          } else if (option.description && (!option.elems || option.elems == 1) && (range = option.description.match("^\\[(.*)\\.\\.(.*)\\]$"))) {
+            const minValue = Number(range[1]);
+            const maxValue = Number(range[2]);
+
+            let stepValue = (maxValue - minValue) / 20;
+            if (option.type != "float") {
+              stepValue = Math.round(stepValue);
+              if (stepValue < 1)
+                stepValue = 1;
+            }
+
+            const inputRangeEl = document.createElement("input");
+            inputRangeEl.id = id_key;
+            inputRangeEl.type = "range";
+            inputRangeEl.className = "default-action";
+            inputRangeEl.min = minValue;
+            inputRangeEl.max = maxValue;
+            inputRangeEl.step = stepValue;
+            inputRangeEl.style = "width: 100px";
+            if (option.value)
+              inputRangeEl.value = Number(option.value);
+            else
+              inputRangeEl.value = "?";
+            groupEl.appendChild(inputRangeEl);
+
+            const inputNumberEl = document.createElement("input");
+            inputNumberEl.id = id_key;
+            inputNumberEl.type = "number";
+            //inputNumberEl.className = "default-action";
+            inputNumberEl.className = "range-max";
+            inputNumberEl.style = "width: 20px";
+            inputNumberEl.min = minValue;
+            inputNumberEl.max = maxValue;
+            inputNumberEl.step = stepValue;
+            inputNumberEl.size = "4";
+            if (option.value)
+              inputNumberEl.value = Number(option.value);
+            else
+              inputNumberEl.value = "?";
+            groupEl.appendChild(inputNumberEl);
+
+            inputRangeEl.onchange = () => {
+              sendOptionValue(device.name, key, inputRangeEl.value);
+              inputNumberEl.value = inputRangeEl.value;
+            }
+            inputNumberEl.onchange = () => {
+              sendOptionValue(device.name, key, inputNumberEl.value);
+              inputRangeEl.value = inputNumberEl.value;
+            }
+          } else {
+            const divEl = document.createElement("div");
+            divEl.className = "text";
+            groupEl.appendChild(divEl);
+
+            const inputEl = document.createElement("input");
+            inputEl.id = id_key;
+            inputEl.type = "text";
+            inputEl.className = "default-action";
+            if (option.value)
+              inputEl.value = option.value;
+            else
+              inputEl.value = "?";
+            divEl.appendChild(inputEl);
+
+            if (option.description) {
+              const divDescriptionEl = document.createElement("div");
+              divDescriptionEl.className = "range-max";
+              divDescriptionEl.textContent = option.description;
+              divEl.appendChild(divDescriptionEl);
+            }
+
+            inputEl.onchange = () => {
+              sendOptionValue(device.name, key, inputEl.value);
+            }
+          }
+          break;
+      }
+    }
+
+    const createControls = (state) => {
+      for (var device of state.devices) {
+        const heading = insertControl("h1");
+        heading.textContent = device.name;
+
+        for (var key in device.options) {
+          createDeviceOption(device, key, device.options[key]);
+        }
+      }
+    };
+
+    var rtcPeerConfig = {
+      sdpSemantics: 'unified-plan'
+    };
+
+    rtcPeerConnection = new RTCPeerConnection(rtcPeerConfig);
+
+    // read initial values
+    fetch(`status`)
+      .then(function (response) {
+        return response.json()
+      })
+      .then(function (state) {
+        hide(waitSettings);
+        show(settings);
+        configureEndpoints(state);
+        createControls(state);
+      })
+
+    const streamContainer = document.getElementById("stream-container");
+    const videoContainer = document.getElementById("video-container");
+
+    const stopStream = () => {
+      window.stop();
+      rtcPeerConnection.close();
+      hide(streamContainer);
+      hide(videoContainer);
+    }
+
+    document.getElementById('get-still').onclick = () => {
+      stopStream();
+      const view = document.getElementById("stream-view");
+      view.src = `${snapshotURL}?_cb=${Date.now()}`;
+      view.scrollIntoView(false);
+      show(streamContainer);
+    }
+
+    document.getElementById('mjpeg-stream').onclick = () => {
+      stopStream();
+      const view = document.getElementById("stream-view");
+      view.src = `${streamURL}?_cb=${Date.now()}`;
+      view.scrollIntoView(false);
+      show(streamContainer);
+    }
+
+    document.getElementById('webrtc-stream').onclick = () => {
+      stopStream();
+      show(videoContainer);
+
+      fetch(webrtcURL, {
+        body: JSON.stringify({type: 'request'}),
+        headers: {'Content-Type': 'application/json'},
+        method: 'POST'
+      }).then(function(response) {
+        return response.json();
+      }).then(function(answer) {
+        rtcPeerConnection = new RTCPeerConnection(rtcPeerConfig);
+        rtcPeerConnection.addTransceiver('video', { direction: 'recvonly' });
+        //pc.addTransceiver('audio', {direction: 'recvonly'});
+        rtcPeerConnection.addEventListener('track', function(evt) {
+          console.log("track event " + evt.track.kind);
+          if (evt.track.kind == 'video') {
+            const view = document.getElementById("video-view");
+            view.srcObject = evt.streams[0];
+            view.scrollIntoView(false);
+          }
+        });
+        rtcPeerConnection.remote_pc_id = answer.id;
+        return rtcPeerConnection.setRemoteDescription(answer);
+      }).then(function() {
+        return rtcPeerConnection.createAnswer();
+      }).then(function(answer) {
+        return rtcPeerConnection.setLocalDescription(answer);
+      }).then(function() {
+        // wait for ICE gathering to complete
+        return new Promise(function(resolve) {
+          if (rtcPeerConnection.iceGatheringState === 'complete') {
+            resolve();
+          } else {
+            function checkState() {
+              if (rtcPeerConnection.iceGatheringState === 'complete') {
+                rtcPeerConnection.removeEventListener('icegatheringstatechange', checkState);
+                resolve();
+              }
+            }
+            rtcPeerConnection.addEventListener('icegatheringstatechange', checkState);
+          }
+        });
+      }).then(function(answer) {
+        var offer = rtcPeerConnection.localDescription;
+
+        return fetch(webrtcURL, {
+          body: JSON.stringify({
+            type: offer.type,
+            id: rtcPeerConnection.remote_pc_id,
+            sdp: offer.sdp,
+          }),
+          headers: { 'Content-Type': 'application/json' },
+          method: 'POST'
+        })
+      }).then(function(response) {
+        return response.json();
+      }).catch(function(e) {
+        alert(e);
+      });
+    }
+  })
+  </script>
+</html>

--- a/html/index.html
+++ b/html/index.html
@@ -59,11 +59,9 @@
 			<a href="option"><b>/option</b></a><br>
 			<br>
 			<ul>
-				<li>See all configurable options cameras.</li>
+				<li>See all configurable camera options.</li>
 				<br>
-				<li><a href="option?key=value">/option?key=value</a> set <i>key</i> to <i>value</i>.</li>
-				<br>
-				<li><a href="option?AfTrigger=1">/option?AfTrigger=1</a> trigger auto focus for ArduCams.</li>
+				<li>POST /option?device=CAMERA&key=AfMode&value=auto</a> to set <i>AfMode</i> on <i>CAMERA</i>.</li>
 			</ul>
 		</li>
 		<br>

--- a/html/webrtc.html
+++ b/html/webrtc.html
@@ -51,9 +51,10 @@
             sdpSemantics: 'unified-plan'
         };
 
-        if (document.getElementById('use-stun') && document.getElementById('use-stun').checked) {
-          config.iceServers = [{urls: ['stun:stun.l.google.com:19302']}];
-        }
+        // syntax: https://github.com/paullouisageneau/libdatachannel/blob/master/DOC.md#rtcwebrtc_peer_connection
+        const ice_servers = [
+          // 'stun:stun.l.google.com:19302'
+        ];
 
         pc = new RTCPeerConnection(config);
         pc.addTransceiver('video', {direction: 'recvonly'});
@@ -76,7 +77,8 @@
         fetch(window.location.href, {
           body: JSON.stringify({
               type: 'request',
-              res: params.res
+              res: params.res,
+              ice_servers: ice_servers
           }),
           headers: {
               'Content-Type': 'application/json'

--- a/html/webrtc.html
+++ b/html/webrtc.html
@@ -12,73 +12,126 @@
     }
 
     #streamStage {
-      position:fixed;
-      top:0;
-      left:0;
       width:100%;
       height:100%;
-    }
-
-    #streamStage:before {
-      content: '';
-      box-sizing: border-box;
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      width: 2rem;
-      height: 2rem;
-      margin-top: -1rem;
-      margin-left: -1rem;
     }
 
     #stream {
       max-height: 100%;
       max-width: 100%;
       margin: auto;
-      position: absolute;
       top: 0; left: 0; bottom: 0; right: 0;
+    }
+
+    #controls {
+        background-color: #6e6e6e;
+        color: white;
+    }
+
+    #controlItem {
+        padding: 5px;
+    }
+
+    #log {
+        margin: 5px;
+        color:white;
+        padding: 5px;
+        width: 98%;
+        height: 200px;
+        background-color:#3d3636;
     }
   </style>
 </head>
 <body>
+  <div id="controls">
+    <div id="controlItem">
+        <input type="checkbox" id="disableLanConnection" onchange="saveLocalSettings()">
+        <label for="disableLanConnection">Disable LAN Connection (remote local ICE candidates from SDP offer and answer)</label>
+    </div>
+    <div id="controlItem">
+      <input type="checkbox" id="disableStunConnection" onchange="saveLocalSettings()">
+      <label for="disableStunConnection">Disable STUN Connection (remote local STUN candidates from SDP offer and answer)</label>
+  </div>
+    <div id="controlItem">
+        <input type="checkbox" id="autoConnect" onchange="saveLocalSettings()" >
+        <label for="autoConnect">Auto Connect On Page Load</label>
+    </div>
+      <div id="controlItem">
+        <label for="requestUrl" >WebRTC Request URL:</label><br/>
+        <input type="text" id="requestUrl" style="width:200px; margin-top:5px;" onchange="saveLocalSettings()"/>
+    </div>
+    <div id="controlItem">
+        <label for="iceServers" >Ice Servers:</label><br/>
+        <label>Syntax must match the <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer/urls" style="color:white;">WebRTC Peer Connection iceServers list.</a></label><br/>
+        <input type="text" id="iceServers" placeholder="Optional comma separated STUN or TURN servers" style="width: 700px; margin-top:5px;" onchange="saveLocalSettings()"/>
+    </div>
+    <div id="controlItem">
+        <button style="padding:5px; width: 200px;" id="connectButton" onclick="startWebRTC();">
+            Connect
+        </button>
+    </div>
+  </div>
+  <div>
+    <textarea id="log" ></textarea>
+  </div>
   <div id="streamtage">
     <video controls autoplay muted playsinline id="stream"></video>
   </div>
 
   <script>
     function startWebRTC() {
-        var config = {
-            sdpSemantics: 'unified-plan'
-        };
-
-        // syntax: https://github.com/paullouisageneau/libdatachannel/blob/master/DOC.md#rtcwebrtc_peer_connection
-        const ice_servers = [
-          // 'stun:stun.l.google.com:19302'
-        ];
-
-        pc = new RTCPeerConnection(config);
-        pc.addTransceiver('video', {direction: 'recvonly'});
-        //pc.addTransceiver('audio', {direction: 'recvonly'});
-        pc.addEventListener('track', function(evt) {
-          console.log("track event " + evt.track.kind);
-            if (evt.track.kind == 'video') {
-                if (document.getElementById('stream')) {
-                  document.getElementById('stream').srcObject = evt.streams[0];
-                }
-            } else {
-                if (document.getElementById('audio'))
-                  document.getElementById('audio').srcObject = evt.streams[0];
-            }
-        });
-
+        var pc = null;
+        const requestUrl = document.getElementById("requestUrl").value;
         const urlSearchParams = new URLSearchParams(window.location.search);
         const params = Object.fromEntries(urlSearchParams.entries());
 
-        fetch(window.location.href, {
+        // Basic singaling flow:
+        //
+        //     Request A WebRTC SDP Offer /webrtc type=request
+        //          Optionally - the client may send a list of ICE servers to use for the connection. This `iceServers` object must match the PeerConnection ice server format.
+        //                Note the server can chose to ingore some ICE servers or add some. The iceServers field returns is what should be set into the PeerConnection.
+        //                Format details: https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer/urls
+        //          As a response, the request will return a json payload with the following:
+        //                sdp - The offer SDP, this is set into WebRTC using `setRemoteDescription`
+        //                iceServers - A json array of ice servers for the connection. These must be set into the PeerConnection's config on create. PeerConnection({ iceServers : <returned iceServers json array>, ... })
+        //     
+        //     Send Back The WebRTC SDP Answer /webrtc type=answer
+        //          localDescription can be recieved from WebRTC when it's ready, it must be sent in the request.
+        //
+        //     Send Trickle ICE candiates as they are ready
+        //           Using PeerConnection.addEventListener("icecandidate", ...) listen for ICE candiates as they become ready.
+        //           Send them to the server using /webrtc type=remote_candidate
+        //
+        //     That's all! If the connection can be made, 
+        //
+
+        // For debugging, we can optioanlly send a list of ICE servers we want to use.
+        // Remember the server may reject or add it's own ICE servers in the reqeust response.
+        var ice_servers = null;
+        try{ 
+          var ice_servers_str = document.getElementById("iceServers").value;
+          ice_servers = JSON.parse(ice_servers_str)
+        } catch (e) {
+          log("Failed to parse ICE servers. "+e)
+          return;
+        }
+
+        // Ensure the array if valid.
+        if(Array.isArray(ice_servers)) {
+          for(var i = 0; i < ice_servers.length; i++) {            
+            log(`Using ICE Server - url:"${ice_servers[i].url}" username:"${ice_servers[i].username}" credential:"${ice_servers[i].credential}"`)
+          }
+        } else {
+          ice_servers = null;
+        } 
+
+        // Start by requesting the SDP offer from the server.
+        log("Requesting SDP offer from server...")
+        fetch(requestUrl, {
           body: JSON.stringify({
               type: 'request',
               res: params.res,
-              ice_servers: ice_servers
+              iceServers: ice_servers
           }),
           headers: {
               'Content-Type': 'application/json'
@@ -87,31 +140,92 @@
         }).then(function(response) {
           return response.json();
         }).then(function(answer) {
+          // Log the servers we got back.
+          for(var i = 0; i < answer.iceServers.length; i++) {            
+            log(`Received ICE Server From Server - url:"${answer.iceServers[i].url}" username:"${answer.iceServers[i].username}" credential:"${answer.iceServers[i].credential}"`)
+          }
+
+          // Setup the PeerConnection
+          var config = {
+            sdpSemantics: 'unified-plan',
+            iceServers: answer["iceServers"]
+          };
+          pc = new RTCPeerConnection(config);          
+          pc.addTransceiver('video', {direction: 'recvonly'});
           pc.remote_pc_id = answer.id;
+
+          // Add listeners.
+          pc.addEventListener('track', function(evt) {
+              log("track event " + evt.track.kind);
+              if (evt.track.kind == 'video') {
+                  if (document.getElementById('stream')) {
+                    document.getElementById('stream').srcObject = evt.streams[0];
+                  }
+              } else {
+                  if (document.getElementById('audio'))
+                    document.getElementById('audio').srcObject = evt.streams[0];
+              }
+          });
+          pc.addEventListener("connectionstatechange",
+            (e) => {
+              log("Local WebRTC connection state changed: "+pc.connectionState)
+            });
+          pc.addEventListener("icecandidate",
+            (e) => {
+              // Fired when the local WebRTC has a new ICE candiate we need to send to the server.
+              if(!e.candidate) {
+                // If e.candiate is null, the local WebRTC done gathering candidates.
+                log("ICE Candidate Gathering Complete")
+                return;
+              }
+
+              // For debugging, it's helpful to block local or stun connections, since they are prefered over TURN
+              if(e.candidate.candidate.indexOf("host") != -1 && document.getElementById("disableLanConnection").checked)
+              {
+                log("Blocking local ICE LAN candidate due to setting.")
+                return;
+              }
+              if(e.candidate.candidate.indexOf("srflx") != -1 && document.getElementById("disableStunConnection").checked)
+              {
+                log("Blocking local ICE STUN candidate due to setting.")
+                return;
+              }
+
+              // We must send the ICE candidate to the server, to indicate to the server it's a possible connection path.
+              log("ICE Candidate Received: "+ JSON.stringify(e.candidate))
+              return fetch(requestUrl, {
+                body: JSON.stringify({
+                  type: 'remote_candidate',
+                  id: pc.remote_pc_id,
+                  candidate: e.candidate
+                }),
+                headers: {
+                  'Content-Type': 'application/json'
+                },
+                method: 'POST'
+              })
+              .catch(function(e) {
+                  log("Failed to send ICE  WebRTC: "+e)
+              });             
+            }
+          );
+
+          // Set the SDP offer.
+          // For debugging, it's sometimes helpful to prevent the LAN conneciton, which this function will do.
+          answer["sdp"] = removeLocalIceCandidateIfNeeded(answer["sdp"])
+          log("Setting remote SDP offer")
+          log(answer["sdp"])
           return pc.setRemoteDescription(answer);
         }).then(function() {
           return pc.createAnswer();
         }).then(function(answer) {
+          log("Setting local SDP answer")
           return pc.setLocalDescription(answer);
-        }).then(function() {
-            // wait for ICE gathering to complete
-            return new Promise(function(resolve) {
-                if (pc.iceGatheringState === 'complete') {
-                    resolve();
-                } else {
-                    function checkState() {
-                        if (pc.iceGatheringState === 'complete') {
-                            pc.removeEventListener('icegatheringstatechange', checkState);
-                            resolve();
-                        }
-                    }
-                    pc.addEventListener('icegatheringstatechange', checkState);
-                }
-            });
         }).then(function(answer) {
+          log("Sending SDP answer")
           var offer = pc.localDescription;
-
-          return fetch(window.location.href, {
+          log(offer)
+          return fetch(requestUrl, {
             body: JSON.stringify({
                 type: offer.type,
                 id: pc.remote_pc_id,
@@ -123,9 +237,10 @@
             method: 'POST'
           })
         }).then(function(response) {
+            log("SDP answer send complete")
             return response.json();
         }).catch(function(e) {
-            alert(e);
+            log("Failed to init WebRTC: "+e)
         });
     }
 
@@ -137,8 +252,76 @@
   </script>
 
   <script>
+    function getLocalStorageBool(name, defaultValue)
+    {
+        var value = localStorage.getItem(name)
+        if(value == null) return defaultValue;
+        return value == "true";
+    }
+
+    function setLocalStorageBool(name, value)
+    {
+        localStorage.setItem(name, value ? "true" : "false");
+    }
+
+    function loadLocalSettings() {
+        document.getElementById("disableLanConnection").checked = getLocalStorageBool("disableLanConnection", false)
+        document.getElementById("disableStunConnection").checked = getLocalStorageBool("disableStunConnection", false)
+        document.getElementById("autoConnect").checked = getLocalStorageBool("autoConnect", false)
+        document.getElementById("iceServers").value = localStorage.getItem("iceServers") == null ? '[  {"url":"stun:stun.l.google.com:19302"}, {"url":"turn:a.relay.metered.ca:80", "username": "7295a68e2381585126c6a19e", "credential": "zDd3R415oPPXJKQT"}  ]' : localStorage.getItem("iceServers")
+        document.getElementById("requestUrl").value = localStorage.getItem("requestUrl") == null ? "/webrtc" : localStorage.getItem("requestUrl")
+    }
+
+    function saveLocalSettings() {
+        setLocalStorageBool("disableLanConnection", document.getElementById("disableLanConnection").checked)
+        setLocalStorageBool("disableStunConnection", document.getElementById("disableStunConnection").checked)
+        setLocalStorageBool("autoConnect", document.getElementById("autoConnect").checked)
+        localStorage.setItem("iceServers", document.getElementById("iceServers").value)
+        localStorage.setItem("requestUrl", document.getElementById("requestUrl").value)
+    }
+
+    function log(msg) {
+        document.getElementById("log").value += msg + "\n";
+        console.log(msg)
+    }
+
+    function removeLocalIceCandidateIfNeeded(sdp) {
+      if(!document.getElementById("disableLanConnection").checked && !document.getElementById("disableStunConnection").checked) {
+        return sdp
+      }
+
+      var outputSdp = "";
+      var lines = sdp.split("\r\n")
+      for(var i = 0; i < lines.length; i++)
+      {
+        var l = lines[i];
+        if(l.length == 0)
+        {
+          continue;
+        }
+        if(l.startsWith('a=candidate') && l.indexOf("host") != -1 && document.getElementById("disableLanConnection").checked)
+        {
+          log("Removing Local ICE candidate: "+l)
+          continue;
+        }
+        if(l.startsWith('a=candidate') && l.indexOf("srflx") != -1 && document.getElementById("disableStunConnection").checked)
+        {
+          log("Removing STUN ICE candidate: "+l)
+          continue;
+        }
+        outputSdp += l + "\r\n";
+      }
+      return outputSdp;
+    }
+  </script>
+
+  <script>
     window.onload = function() {
-      startWebRTC();
+        loadLocalSettings();
+        if(document.getElementById("autoConnect").checked)
+        {
+            startWebRTC();
+        }
     }
   </script>
 </body>

--- a/output/webrtc/webrtc.h
+++ b/output/webrtc/webrtc.h
@@ -10,6 +10,7 @@ typedef struct webrtc_options_s {
   bool running;
   bool disabled;
   char ice_servers[WEBRTC_OPTIONS_LENGTH];
+  bool disable_client_ice;
 } webrtc_options_t;
 
 // WebRTC

--- a/output/webrtc/webrtc.h
+++ b/output/webrtc/webrtc.h
@@ -2,11 +2,14 @@
 
 #include <stdio.h>
 
+#define WEBRTC_OPTIONS_LENGTH 4096
+
 typedef struct http_worker_s http_worker_t;
 
 typedef struct webrtc_options_s {
   bool running;
   bool disabled;
+  char ice_servers[WEBRTC_OPTIONS_LENGTH];
 } webrtc_options_t;
 
 // WebRTC

--- a/util/http/http_methods.c
+++ b/util/http/http_methods.c
@@ -72,5 +72,5 @@ void http_404(FILE *stream, const char *data)
 
 void http_500(FILE *stream, const char *data)
 {
-  http_write_response(stream, "500 Server Error", NULL, data ? data : "Server Error\n", 0);
+  http_write_response(stream, "500 Server Error", "text/plain", data ? data : "Server Error\n", 0);
 }

--- a/util/http/json.hh
+++ b/util/http/json.hh
@@ -1,0 +1,27 @@
+#pragma once
+
+extern "C" {
+#include "http.h"
+}
+
+#include <stdio.h>
+#include <nlohmann/json.hpp>
+
+inline nlohmann::json http_parse_json_body(http_worker_t *worker, FILE *stream, unsigned max_body_size)
+{
+  std::string text;
+
+  size_t i = 0;
+  size_t n = (size_t)worker->content_length;
+  if (n < 0 || n > max_body_size)
+    n = max_body_size;
+
+  text.resize(n);
+
+  while (i < n && !feof(stream)) {
+    i += fread(&text[i], 1, n-i, stream);
+  }
+  text.resize(i);
+
+  return nlohmann::json::parse(text);
+}

--- a/util/opts/control.c
+++ b/util/opts/control.c
@@ -4,17 +4,23 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+static bool isalnum_dot(char c)
+{
+  return isalnum(c) || c == '.';
+}
+
 int device_option_normalize_name(const char *in, char *outp)
 {
   // The output is always shorter, so `outp=in`
   // colour_correction_matrix => colourcorrectionmatrix
   // Colour Correction Matrix => colourcorrectionmatrix
   // ColourCorrectionMatrix => colourcorrectionmatrix
+  // Colour.Correction.Matrix => colour.correction.matrix
 
   char *out = outp;
 
   while (*in) {
-    if (isalnum(*in)) {
+    if (isalnum_dot(*in)) {
       *out++ = tolower(*in++);
     } else {
       in++;
@@ -22,5 +28,26 @@ int device_option_normalize_name(const char *in, char *outp)
   }
 
   *out++ = 0;
-  return out - outp;
+  return out - outp - 1;
+}
+
+bool device_option_is_equal(const char *a, const char *b)
+{
+  // Similar to device_option_normalize_name
+  // but ignore case sensitiveness
+
+  while (*a || *b) {
+    while (*a && !isalnum_dot(*a))
+      a++;
+    while (*b && !isalnum_dot(*b))
+      b++;
+
+    if (tolower(*a) != tolower(*b))
+      return 0;
+
+    a++;
+    b++;
+  }
+
+  return 1;
 }

--- a/util/opts/control.h
+++ b/util/opts/control.h
@@ -1,1 +1,4 @@
+#include <stdbool.h>
+
 int device_option_normalize_name(const char *in, char *out);
+bool device_option_is_equal(const char *a, const char *b);

--- a/util/opts/helpers.hh
+++ b/util/opts/helpers.hh
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <sstream>
+
+inline std::vector<std::string> str_split(const std::string& in, const char seperator)
+{
+  std::vector<std::string> output;
+  std::istringstream stream(in);
+  for (std::string s; std::getline(stream, s, seperator); ) {
+    output.push_back(s);
+  }
+  return output;
+}

--- a/util/opts/opts.h
+++ b/util/opts/opts.h
@@ -26,6 +26,7 @@ typedef struct options_s {
   const char *description;
 } option_t;
 
+#define OPTION_VALUE_LIST_SEP_CHAR ';'
 #define OPTION_VALUE_LIST_SEP ";"
 
 #define OPTION_FORMAT_uint   "%u"


### PR DESCRIPTION
Since libdatachannels is advertising support for trickle ICE in the SDP offer, we should support it since WebRTC clients will use it. Tickle ICE lets the connection be faster by streaming the possible ICE candidates out as they become available instead of waiting until all have been resolved and then sending the remote description.

This change also allows all ICE candidates to be considered for possible candidates for the connection. Before this, only one ICE candidate was returned in the answer SDK; thus, it was the only one "agreed upon" by the client and server. This worked in most local setups since there was only one server candidate anyways. But even in local scenarios where the device has more than one IP address (like v4 and v6), ICE negotiation could fail. This change also enables lower-priority ICE candidates like STUN or TURN servers to be used as fallbacks.