### PR TITLE
Just a few small WebRTC ICE Server Fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@
 - device: show stddev estimates to measure frame pacing
 - webrtc: allow to specify ice-servers on command line
 - webrtc: accept `ice_servers` provided in `POST /webrtc`
+- device: support `--camera-crop.left/right/top/bottom` in a %
 
 ## Variants
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 - http: add `/control` to provide simple JS interface to live edit camera settings
 - http: change `/option` to accept `device=`, `key=`, and `value=`
 - device: show stddev estimates to measure frame pacing
+- webrtc: allow to specify ice-servers on command line
 
 ## Variants
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 - http: change `/option` to accept `device=`, `key=`, and `value=`
 - device: show stddev estimates to measure frame pacing
 - webrtc: allow to specify ice-servers on command line
+- webrtc: accept `ice_servers` provided in `POST /webrtc`
 
 ## Variants
 

--- a/cmd/camera-streamer/opts.c
+++ b/cmd/camera-streamer/opts.c
@@ -131,6 +131,8 @@ option_t all_options[] = {
 
   DEFINE_OPTION_DEFAULT(rtsp, port, uint, "8554", "Set the RTSP server port (default: 8854)."),
 
+  DEFINE_OPTION_PTR(webrtc, ice_servers, list, "Specify ICE servers: [(stun|turn|turns)(:|://)][username:password@]hostname[:port][?transport=udp|tcp|tls)]."),
+
   DEFINE_OPTION_DEFAULT(log, debug, bool, "1", "Enable debug logging."),
   DEFINE_OPTION_DEFAULT(log, verbose, bool, "1", "Enable verbose logging."),
   DEFINE_OPTION_DEFAULT(log, stats, uint, "1", "Print statistics every duration."),

--- a/cmd/camera-streamer/opts.c
+++ b/cmd/camera-streamer/opts.c
@@ -132,6 +132,7 @@ option_t all_options[] = {
   DEFINE_OPTION_DEFAULT(rtsp, port, uint, "8554", "Set the RTSP server port (default: 8854)."),
 
   DEFINE_OPTION_PTR(webrtc, ice_servers, list, "Specify ICE servers: [(stun|turn|turns)(:|://)][username:password@]hostname[:port][?transport=udp|tcp|tls)]."),
+  DEFINE_OPTION_DEFAULT(webrtc, disable_client_ice, bool, "1", "Ignore ICE servers provided in '/webrtc' request."),
 
   DEFINE_OPTION_DEFAULT(log, debug, bool, "1", "Enable debug logging."),
   DEFINE_OPTION_DEFAULT(log, verbose, bool, "1", "Enable verbose logging."),

--- a/cmd/camera-streamer/opts.c
+++ b/cmd/camera-streamer/opts.c
@@ -111,6 +111,11 @@ option_t all_options[] = {
   DEFINE_OPTION_DEFAULT(camera, vflip, bool, "1", "Do vertical image flip (does not work with all camera)."),
   DEFINE_OPTION_DEFAULT(camera, hflip, bool, "1", "Do horizontal image flip (does not work with all camera)."),
 
+  DEFINE_OPTION(camera, crop.left, float, "Set the image crop."),
+  DEFINE_OPTION(camera, crop.top, float, "Set the image crop."),
+  DEFINE_OPTION(camera, crop.right, float, "Set the image crop."),
+  DEFINE_OPTION(camera, crop.bottom, float, "Set the image crop."),
+
   DEFINE_OPTION_PTR(camera, isp.options, list, "Set the ISP processing options. List all available options with `-camera-list_options`."),
 
   DEFINE_OPTION_PTR(camera, snapshot.options, list, "Set the JPEG compression options. List all available options with `-camera-list_options`."),

--- a/device/buffer.h
+++ b/device/buffer.h
@@ -28,6 +28,7 @@ typedef struct buffer_s {
     struct buffer_v4l2_s *v4l2;
     struct buffer_dummy_s *dummy;
     struct buffer_libcamera_s *libcamera;
+    struct buffer_sw_s *sw;
   };
 
   // State

--- a/device/buffer_list.h
+++ b/device/buffer_list.h
@@ -22,6 +22,10 @@ typedef struct buffer_format_s {
   buffer_type_t type;
 } buffer_format_t;
 
+typedef struct buffer_rect_s {
+  unsigned x, y, width, height;
+} buffer_rect_t;
+
 typedef struct buffer_stats_s {
   int frames, dropped;
 
@@ -42,7 +46,7 @@ typedef struct buffer_list_s {
   int index;
 
   buffer_format_t fmt;
-  bool do_mmap, do_capture, do_timestamps;
+  bool do_mmap, do_capture, do_timestamps, do_not_find;
 
   union {
     struct buffer_list_v4l2_s *v4l2;

--- a/device/buffer_list.h
+++ b/device/buffer_list.h
@@ -51,6 +51,7 @@ typedef struct buffer_list_s {
   union {
     struct buffer_list_v4l2_s *v4l2;
     struct buffer_list_dummy_s *dummy;
+    struct buffer_list_sw_s *sw;
     struct buffer_list_libcamera_s *libcamera;
   };
 

--- a/device/camera/camera.h
+++ b/device/camera/camera.h
@@ -25,9 +25,14 @@ typedef struct camera_output_options_s {
   char options[CAMERA_OPTIONS_LENGTH];
 } camera_output_options_t;
 
+typedef struct camera_crop_s {
+  float left, top, right, bottom;
+} camera_crop_t;
+
 typedef struct camera_options_s {
   char path[256];
   unsigned width, height, format;
+  camera_crop_t crop;
   unsigned nbufs, fps;
   camera_type_t type;
   bool allow_dma;
@@ -93,11 +98,14 @@ void camera_capture_add_output(camera_t *camera, buffer_list_t *capture, buffer_
 void camera_capture_add_callbacks(camera_t *camera, buffer_list_t *capture, link_callbacks_t callbacks);
 
 int camera_configure_input(camera_t *camera);
-int camera_configure_pipeline(camera_t *camera, buffer_list_t *camera_capture);
+int camera_configure_pipeline(camera_t *camera, buffer_list_t *camera_capture, camera_crop_t *crop);
 void camera_debug_capture(camera_t *camera, buffer_list_t *capture);
+
+bool camera_uses_crop(camera_crop_t *crop);
+int camera_configure_crop(device_t *dev, buffer_format_t fmt, camera_crop_t *crop);
 
 buffer_list_t *camera_configure_isp(camera_t *camera, buffer_list_t *src_capture);
 buffer_list_t *camera_configure_decoder(camera_t *camera, buffer_list_t *src_capture);
 buffer_list_t *camera_configure_rescaller(camera_t *camera, buffer_list_t *src_capture, const char *name, unsigned target_height, unsigned formats[]);
-int camera_configure_output(camera_t *camera, buffer_list_t *camera_capture, const char *name, camera_output_options_t *options, unsigned formats[], link_callbacks_t callbacks, device_t **device);
+int camera_configure_output(camera_t *camera, buffer_list_t *camera_capture, const char *name, camera_crop_t *crop, camera_output_options_t *options, unsigned formats[], link_callbacks_t callbacks, device_t **device);
 bool camera_get_scaled_resolution(buffer_format_t capture_format, camera_output_options_t *options, buffer_format_t *format, int align_size);

--- a/device/camera/camera_crop.c
+++ b/device/camera/camera_crop.c
@@ -1,0 +1,48 @@
+#include "camera.h"
+
+#include "device/buffer_list.h"
+#include "device/device.h"
+#include "util/opts/log.h"
+
+bool camera_uses_crop(camera_crop_t *crop)
+{
+  if (!crop) {
+    return false;
+  }
+
+  if (crop->left <= 0 && crop->right <= 0 &&
+    crop->top <= 0 && crop->bottom <= 0) {
+    return false;
+  }
+
+  return true;
+}
+
+int camera_configure_crop(device_t *dev, buffer_format_t fmt, camera_crop_t *crop)
+{
+  if (!camera_uses_crop(crop))
+    return 0;
+
+  int x = fmt.width * crop->left;
+  int y = fmt.height * crop->top;
+  int width = fmt.width * (1.0 - crop->left - crop->right);
+  int height = fmt.height * (1.0 - crop->top - crop->bottom);
+
+  if (x < 0 || y < 0 || width <= 1 || height <= 1) {
+    LOG_INFO(dev, "CROP settings do not make sense: %dx%d/(%dx%d)",
+      x, y, width, height);
+    return -1;
+  }
+
+  LOG_INFO(dev, "CROP: %dx%d/(%dx%d)",
+    x, y, width, height);
+
+  buffer_rect_t rect = {
+    .x = x,
+    .y = y,
+    .width = width,
+    .height = height,
+  };
+
+  return device_set_target_crop(dev, &rect);
+}

--- a/device/camera/camera_input.c
+++ b/device/camera/camera_input.c
@@ -44,7 +44,14 @@ static int camera_configure_input_v4l2(camera_t *camera)
     return -1;
   }
 
-  return camera_configure_pipeline(camera, camera_capture);
+  camera_crop_t *crop = NULL;
+
+  if (camera_uses_crop(&camera->options.crop)) {
+    camera_capture->do_not_find = true;
+    crop = &camera->options.crop;
+  }
+
+  return camera_configure_pipeline(camera, camera_capture, crop);
 }
 
 static int camera_configure_input_libcamera(camera_t *camera)
@@ -98,7 +105,14 @@ static int camera_configure_input_libcamera(camera_t *camera)
     return -1;
   }
 
-  return camera_configure_pipeline(camera, camera_capture);
+  camera_crop_t *crop = NULL;
+
+  if (camera_uses_crop(&camera->options.crop)) {
+    camera_capture->do_not_find = true;
+    crop = &camera->options.crop;
+  }
+
+  return camera_configure_pipeline(camera, camera_capture, crop);
 }
 
 static int camera_configure_input_dummy(camera_t *camera)
@@ -120,7 +134,14 @@ static int camera_configure_input_dummy(camera_t *camera)
     return -1;
   }
 
-  return camera_configure_pipeline(camera, camera_capture);
+  camera_crop_t *crop = NULL;
+
+  if (camera_uses_crop(&camera->options.crop)) {
+    camera_capture->do_not_find = true;
+    crop = &camera->options.crop;
+  }
+
+  return camera_configure_pipeline(camera, camera_capture, crop);
 }
 
 int camera_configure_input(camera_t *camera)

--- a/device/camera/camera_pipeline.c
+++ b/device/camera/camera_pipeline.c
@@ -42,23 +42,23 @@ static link_callbacks_t video_callbacks =
   .buf_lock = &video_lock
 };
 
-int camera_configure_pipeline(camera_t *camera, buffer_list_t *camera_capture)
+int camera_configure_pipeline(camera_t *camera, buffer_list_t *camera_capture, camera_crop_t *crop)
 {
   camera_capture->do_timestamps = true;
 
   camera_debug_capture(camera, camera_capture);
 
-  if (camera_configure_output(camera, camera_capture, "SNAPSHOT", &camera->options.snapshot,
+  if (camera_configure_output(camera, camera_capture, "SNAPSHOT", crop, &camera->options.snapshot,
     snapshot_formats, snapshot_callbacks, &camera->codec_snapshot) < 0) {
     return -1;
   }
 
-  if (camera_configure_output(camera, camera_capture, "STREAM", &camera->options.stream,
+  if (camera_configure_output(camera, camera_capture, "STREAM", crop, &camera->options.stream,
     snapshot_formats, stream_callbacks, &camera->codec_stream) < 0) {
     return -1;
   }
 
-  if (camera_configure_output(camera, camera_capture, "VIDEO", &camera->options.video,
+  if (camera_configure_output(camera, camera_capture, "VIDEO", crop, &camera->options.video,
     video_formats, video_callbacks, &camera->codec_video) < 0) {
     return -1;
   }

--- a/device/device.c
+++ b/device/device.c
@@ -241,6 +241,18 @@ int device_set_rotation(device_t *dev, bool vflip, bool hflip)
   return hret ? hret : vret;
 }
 
+int device_set_target_crop(device_t *dev, const buffer_rect_t *rect)
+{
+  if (!dev || !rect)
+    return -1;
+
+  if (dev->hw->device_set_target_crop) {
+    return dev->hw->device_set_target_crop(dev, rect);
+  }
+
+  return -1;
+}
+
 int device_set_option_string(device_t *dev, const char *key, const char *value)
 {
   if (dev && dev->hw->device_set_option) {

--- a/device/device.h
+++ b/device/device.h
@@ -7,6 +7,7 @@
 typedef struct buffer_s buffer_t;
 typedef struct buffer_list_s buffer_list_t;
 typedef struct buffer_format_s buffer_format_t;
+typedef struct buffer_rect_s buffer_rect_t;
 typedef struct device_option_s device_option_t;
 typedef struct device_s device_t;
 struct pollfd;
@@ -22,6 +23,7 @@ typedef struct device_hw_s {
   int (*device_set_fps)(device_t *dev, int desired_fps);
   int (*device_set_rotation)(device_t *dev, bool vflip, bool hflip);
   int (*device_set_option)(device_t *dev, const char *key, const char *value);
+  int (*device_set_target_crop)(device_t *dev, const buffer_rect_t *rect);
 
   int (*buffer_open)(buffer_t *buf);
   void (*buffer_close)(buffer_t *buf);
@@ -111,6 +113,7 @@ void device_dump_options(device_t *dev, FILE *stream);
 int device_dump_options2(device_t *dev, device_option_fn fn, void *opaque);
 int device_set_fps(device_t *dev, int desired_fps);
 int device_set_rotation(device_t *dev, bool vflip, bool hflip);
+int device_set_target_crop(device_t *dev, const buffer_rect_t *rect);
 int device_set_option_string(device_t *dev, const char *option, const char *value);
 void device_set_option_list(device_t *dev, const char *option_list);
 

--- a/device/device.h
+++ b/device/device.h
@@ -56,6 +56,7 @@ typedef struct device_s {
     struct device_v4l2_s *v4l2;
     struct device_dummy_s *dummy;
     struct device_libcamera_s *libcamera;
+    struct device_sw_t *sw;
   };
 
   bool paused;

--- a/device/sw/buffer.c
+++ b/device/sw/buffer.c
@@ -1,0 +1,88 @@
+#include "sw.h"
+#include "device/buffer.h"
+#include "device/buffer_list.h"
+#include "util/opts/log.h"
+#include "util/opts/fourcc.h"
+
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+int sw_buffer_open(buffer_t *buf)
+{
+  buf->sw = calloc(1, sizeof(buffer_sw_t));
+
+  if (!buf->buf_list->do_mmap) {
+    switch (buf->buf_list->fmt.format) {
+    case V4L2_PIX_FMT_YUYV:
+      buf->length = buf->buf_list->fmt.width * buf->buf_list->fmt.height * 2;
+      break;
+
+    default:
+      LOG_INFO(buf->buf_list, "The format is not supported '%s'",
+        fourcc_to_string(buf->buf_list->fmt.format).buf);
+      return -1;
+    }
+
+    buf->start = malloc(buf->length);
+    if (!buf->start) {
+      LOG_INFO(buf, "Failed to allocate %lu bytes for '%s'",
+        buf->length,
+        fourcc_to_string(buf->buf_list->fmt.format).buf);
+      return -1;
+    }
+  }
+
+  buf->used = 0;
+  return 0;
+}
+
+void sw_buffer_close(buffer_t *buf)
+{
+  if (!buf->buf_list->do_mmap) {
+    free(buf->start);
+  }
+  free(buf->sw);
+}
+
+int sw_buffer_enqueue(buffer_t *buf, const char *who)
+{
+  unsigned index = buf->index;
+  if (write(buf->buf_list->sw->send_fds[1], &index, sizeof(index)) != sizeof(index)) {
+    return -1;
+  }
+  return 0;
+}
+
+int sw_buffer_list_dequeue(buffer_list_t *buf_list, buffer_t **bufp)
+{
+  unsigned index = 0;
+  int n = read(buf_list->sw->recv_fds[0], &index, sizeof(index));
+  if (n != sizeof(index)) {
+    LOG_INFO(buf_list, "Received invalid result from `read`: %d", n);
+    return -1;
+  }
+
+  if (index >= (unsigned)buf_list->nbufs) {
+    LOG_INFO(buf_list, "Received invalid index from `read`: %d >= %d", index, buf_list->nbufs);
+    return -1;
+  }
+
+  *bufp = buf_list->bufs[index];
+  return 0;
+}
+
+int sw_buffer_list_pollfd(buffer_list_t *buf_list, struct pollfd *pollfd, bool can_dequeue)
+{
+  int count_enqueued = buffer_list_count_enqueued(buf_list);
+  pollfd->fd = buf_list->sw->recv_fds[0]; // write end
+  pollfd->events = POLLHUP;
+  if (can_dequeue && count_enqueued > 0) {
+    if (buf_list->do_capture)
+      pollfd->events |= POLLIN;
+    else
+      pollfd->events |= POLLOUT;
+  }
+  pollfd->revents = 0;
+  return 0;
+}

--- a/device/sw/buffer_list.c
+++ b/device/sw/buffer_list.c
@@ -1,0 +1,75 @@
+#include "sw.h"
+#include "device/buffer_list.h"
+#include "device/device.h"
+#include "util/opts/log.h"
+#include "util/opts/fourcc.h"
+
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+int sw_buffer_list_open(buffer_list_t *buf_list)
+{
+  if (buf_list->do_capture) {
+    buf_list->do_mmap = false;
+
+    switch (buf_list->fmt.format) {
+    case V4L2_PIX_FMT_YUYV:
+      break;
+
+    default:
+      LOG_INFO(buf_list, "The format is not supported '%s'",
+        fourcc_to_string(buf_list->fmt.format).buf);
+      return -1;
+    }
+  } else {
+    switch (buf_list->fmt.format) {
+    case V4L2_PIX_FMT_JPEG:
+    case V4L2_PIX_FMT_MJPEG:
+      break;
+
+    default:
+      LOG_INFO(buf_list, "The format is not supported '%s'",
+        fourcc_to_string(buf_list->fmt.format).buf);
+      return -1;
+    }
+  }
+
+  buf_list->sw = calloc(1, sizeof(buffer_list_sw_t));
+  buf_list->sw->send_fds[0] = -1;
+  buf_list->sw->send_fds[1] = -1;
+  buf_list->sw->recv_fds[0] = -1;
+  buf_list->sw->recv_fds[1] = -1;
+
+  if (pipe2(buf_list->sw->send_fds, O_DIRECT|O_CLOEXEC) < 0) {
+    LOG_INFO(buf_list, "Cannot open `pipe2`.");
+    return -1;
+  }
+
+  if (pipe2(buf_list->sw->recv_fds, O_DIRECT|O_CLOEXEC) < 0) {
+    LOG_INFO(buf_list, "Cannot open `pipe2`.");
+    close(buf_list->sw->send_fds[0]);
+    close(buf_list->sw->send_fds[1]);
+    return -1;
+  }
+
+  return buf_list->fmt.nbufs;
+}
+
+void sw_buffer_list_close(buffer_list_t *buf_list)
+{
+  if (buf_list->sw) {
+    close(buf_list->sw->send_fds[0]);
+    close(buf_list->sw->send_fds[1]);
+    close(buf_list->sw->recv_fds[0]);
+    close(buf_list->sw->recv_fds[1]);
+    free(buf_list->sw->data);
+  }
+
+  free(buf_list->sw);
+}
+
+int sw_buffer_list_set_stream(buffer_list_t *buf_list, bool do_on)
+{
+  return 0;
+}

--- a/device/sw/device.c
+++ b/device/sw/device.c
@@ -1,0 +1,16 @@
+#include "sw.h"
+#include "device/device.h"
+
+#include <stdlib.h>
+
+int sw_device_open(device_t *dev)
+{
+  dev->opts.allow_dma = false;
+  dev->sw = calloc(1, sizeof(device_sw_t));
+  return 0;
+}
+
+void sw_device_close(device_t *dev)
+{
+  free(dev->sw);
+}

--- a/device/sw/sw.c
+++ b/device/sw/sw.c
@@ -1,0 +1,23 @@
+#include "sw.h"
+
+#include "device/device.h"
+
+device_hw_t sw_device_hw = {
+  .device_open = sw_device_open,
+  .device_close = sw_device_close,
+
+  .buffer_open = sw_buffer_open,
+  .buffer_close = sw_buffer_close,
+  .buffer_enqueue = sw_buffer_enqueue,
+
+  .buffer_list_dequeue = sw_buffer_list_dequeue,
+  .buffer_list_pollfd = sw_buffer_list_pollfd,
+  .buffer_list_open = sw_buffer_list_open,
+  .buffer_list_close = sw_buffer_list_close,
+  .buffer_list_set_stream = sw_buffer_list_set_stream
+};
+
+device_t *device_sw_open(const char *name, const char *path)
+{
+  return device_open(name, path, &sw_device_hw);
+}

--- a/device/sw/sw.h
+++ b/device/sw/sw.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <unistd.h>
+
+typedef struct buffer_s buffer_t;
+typedef struct buffer_list_s buffer_list_t;
+typedef struct device_s device_t;
+struct pollfd;
+
+typedef struct device_sw_s {
+} device_sw_t;
+
+typedef struct buffer_list_sw_s {
+  int send_fds[2], recv_fds[2];
+  void *data;
+  size_t length;
+} buffer_list_sw_t;
+
+typedef struct buffer_sw_s {
+} buffer_sw_t;
+
+int sw_device_open(device_t *dev);
+void sw_device_close(device_t *dev);
+
+int sw_buffer_open(buffer_t *buf);
+void sw_buffer_close(buffer_t *buf);
+int sw_buffer_enqueue(buffer_t *buf, const char *who);
+int sw_buffer_list_dequeue(buffer_list_t *buf_list, buffer_t **bufp);
+int sw_buffer_list_pollfd(buffer_list_t *buf_list, struct pollfd *pollfd, bool can_dequeue);
+
+int sw_buffer_list_open(buffer_list_t *buf_list);
+void sw_buffer_list_close(buffer_list_t *buf_list);
+int sw_buffer_list_set_stream(buffer_list_t *buf_list, bool do_on);

--- a/device/sw/thread.c
+++ b/device/sw/thread.c
@@ -1,0 +1,60 @@
+#include "sw.h"
+
+#include "device/device.h"
+#include "device/buffer.h"
+#include "device/buffer_list.h"
+#include "util/opts/log.h"
+#include "util/opts/fourcc.h"
+
+static buffer_t *sw_device_recv_send_buffer(buffer_list_t *buf_list)
+{
+  unsigned index = 0;
+  int n = read(buf_list->sw->send_fds[0], &index, sizeof(index));
+  if (n != sizeof(index)) {
+    LOG_INFO(buf_list, "Received invalid result from `read`: %d", n);
+    return NULL;
+  }
+
+  if (index >= (unsigned)buf_list->nbufs) {
+    LOG_INFO(buf_list, "Received invalid index from `read`: %d >= %d", index, buf_list->nbufs);
+    return NULL;
+  }
+
+  return buf_list->bufs[index];
+}
+
+static int sw_device_send_recv_buffer(buffer_t *buf)
+{
+  unsigned index = buf->index;
+  if (write(buf->buf_list->sw->recv_fds[1], &index, sizeof(index)) != sizeof(index)) {
+    return -1;
+  }
+  return 0;
+}
+
+static void sw_device_process_capture_buf(buffer_t *output_buf, buffer_t *capture_buf)
+{
+  capture_buf->length = 0;
+}
+
+void *sw_device_thread(buffer_list_t *output_list)
+{
+  while (output_list->streaming) {
+    buffer_t *output_buf = sw_device_recv_send_buffer(output_list);
+    if (!output_buf) {
+      continue;
+    }
+
+    buffer_t *capture_buf = sw_device_recv_send_buffer(
+      output_list->dev->capture_lists[0]);
+
+    if (capture_buf) {
+      sw_device_process_capture_buf(output_buf, capture_buf);
+      sw_device_send_recv_buffer(capture_buf);
+    }
+
+    sw_device_send_recv_buffer(output_buf);
+  }
+
+  return NULL;
+}

--- a/device/v4l2/device.c
+++ b/device/v4l2/device.c
@@ -1,4 +1,5 @@
 #include "v4l2.h"
+#include "device/buffer_list.h"
 #include "device/device.h"
 #include "util/opts/log.h"
 
@@ -76,6 +77,33 @@ int v4l2_device_set_fps(device_t *dev, int desired_fps)
   LOG_DEBUG(dev, "Configuring FPS ...");
   ERR_IOCTL(dev, dev->v4l2->dev_fd, VIDIOC_S_PARM, &setfps, "Can't set FPS");
   return 0;
+error:
+  return -1;
+}
+
+int v4l2_device_set_target_crop(device_t *dev, const buffer_rect_t *rect)
+{
+  if (!dev->v4l2)
+    return -1;
+
+  struct v4l2_rect v4l2_rect = {
+    .left = rect->x,
+    .top = rect->y,
+    .width = rect->width,
+    .height = rect->height
+  };
+
+	struct v4l2_selection v4l2_sel = {
+    .type = V4L2_BUF_TYPE_VIDEO_OUTPUT,
+    .target = V4L2_SEL_TGT_CROP,
+    .flags = 0,
+    .r = v4l2_rect
+  };
+
+  ERR_IOCTL(dev, dev->v4l2->dev_fd, VIDIOC_S_SELECTION, &v4l2_sel, "Can't set target crop selection");
+
+  return 0;
+
 error:
   return -1;
 }

--- a/device/v4l2/v4l2.c
+++ b/device/v4l2/v4l2.c
@@ -9,6 +9,7 @@ device_hw_t v4l2_device_hw = {
   .device_dump_options2 = v4l2_device_dump_options2,
   .device_set_fps = v4l2_device_set_fps,
   .device_set_option = v4l2_device_set_option,
+  .device_set_target_crop = v4l2_device_set_target_crop,
 
   .buffer_open = v4l2_buffer_open,
   .buffer_close = v4l2_buffer_close,

--- a/device/v4l2/v4l2.h
+++ b/device/v4l2/v4l2.h
@@ -9,6 +9,7 @@
 
 typedef struct buffer_s buffer_t;
 typedef struct buffer_list_s buffer_list_t;
+typedef struct buffer_rect_s buffer_rect_t;
 typedef struct device_option_s device_option_t;
 typedef struct device_s device_t;
 struct pollfd;
@@ -44,6 +45,7 @@ void v4l2_device_dump_options(device_t *dev, FILE *stream);
 int v4l2_device_dump_options2(device_t *dev, device_option_fn fn, void *opaque);
 int v4l2_device_set_fps(device_t *dev, int desired_fps);
 int v4l2_device_set_option(device_t *dev, const char *key, const char *value);
+int v4l2_device_set_target_crop(device_t *dev, const buffer_rect_t *rect);
 
 int v4l2_buffer_open(buffer_t *buf);
 void v4l2_buffer_close(buffer_t *buf);

--- a/html/control.html
+++ b/html/control.html
@@ -759,8 +759,11 @@
         method: 'POST'
       }).then(function(response) {
         return response.json();
-      }).then(function(answer) {
-        rtcPeerConnection = new RTCPeerConnection(rtcPeerConfig);
+      }).then(function(request) {
+        rtcPeerConnection = new RTCPeerConnection({
+          sdpSemantics: 'unified-plan',
+          iceServers: request.iceServers
+        });
         rtcPeerConnection.addTransceiver('video', { direction: 'recvonly' });
         //pc.addTransceiver('audio', {direction: 'recvonly'});
         rtcPeerConnection.addEventListener('track', function(evt) {
@@ -771,27 +774,27 @@
             view.scrollIntoView(false);
           }
         });
-        rtcPeerConnection.remote_pc_id = answer.id;
-        return rtcPeerConnection.setRemoteDescription(answer);
+        rtcPeerConnection.addEventListener("icecandidate", function(e) {
+          if (e.candidate) {
+            return fetch(webrtcURL, {
+              body: JSON.stringify({
+                type: 'remote_candidate',
+                id: rtcPeerConnection.remote_pc_id,
+                candidates: [e.candidate]
+              }),
+              headers: { 'Content-Type': 'application/json' },
+              method: 'POST'
+            }).catch(function(e) {
+              console.log("Failed to send ICE WebRTC: "+e);
+            });
+          }
+        });
+        rtcPeerConnection.remote_pc_id = request.id;
+        return rtcPeerConnection.setRemoteDescription(request);
       }).then(function() {
         return rtcPeerConnection.createAnswer();
       }).then(function(answer) {
         return rtcPeerConnection.setLocalDescription(answer);
-      }).then(function() {
-        // wait for ICE gathering to complete
-        return new Promise(function(resolve) {
-          if (rtcPeerConnection.iceGatheringState === 'complete') {
-            resolve();
-          } else {
-            function checkState() {
-              if (rtcPeerConnection.iceGatheringState === 'complete') {
-                rtcPeerConnection.removeEventListener('icegatheringstatechange', checkState);
-                resolve();
-              }
-            }
-            rtcPeerConnection.addEventListener('icegatheringstatechange', checkState);
-          }
-        });
       }).then(function(answer) {
         var offer = rtcPeerConnection.localDescription;
 
@@ -807,7 +810,7 @@
       }).then(function(response) {
         return response.json();
       }).catch(function(e) {
-        alert(e);
+        console.log(e);
       });
     }
   })

--- a/html/webrtc.html
+++ b/html/webrtc.html
@@ -47,28 +47,13 @@
 
   <script>
     function startWebRTC() {
-        var config = {
-            sdpSemantics: 'unified-plan'
-        };
+        // syntax: https://github.com/paullouisageneau/libdatachannel/blob/master/DOC.md#rtcwebrtc_peer_connection
+        const ice_servers = [
+          // 'stun:stun.l.google.com:19302',
+          //'turn://7295a68e2381585126c6a19e:zDd3R415oPPXJKQT@a.relay.metered.ca:80'
+        ];
 
-        if (document.getElementById('use-stun') && document.getElementById('use-stun').checked) {
-          config.iceServers = [{urls: ['stun:stun.l.google.com:19302']}];
-        }
-
-        pc = new RTCPeerConnection(config);
-        pc.addTransceiver('video', {direction: 'recvonly'});
-        //pc.addTransceiver('audio', {direction: 'recvonly'});
-        pc.addEventListener('track', function(evt) {
-          console.log("track event " + evt.track.kind);
-            if (evt.track.kind == 'video') {
-                if (document.getElementById('stream')) {
-                  document.getElementById('stream').srcObject = evt.streams[0];
-                }
-            } else {
-                if (document.getElementById('audio'))
-                  document.getElementById('audio').srcObject = evt.streams[0];
-            }
-        });
+        var pc = null;
 
         const urlSearchParams = new URLSearchParams(window.location.search);
         const params = Object.fromEntries(urlSearchParams.entries());
@@ -76,7 +61,8 @@
         fetch(window.location.href, {
           body: JSON.stringify({
               type: 'request',
-              res: params.res
+              res: params.res,
+              ice_servers: ice_servers
           }),
           headers: {
               'Content-Type': 'application/json'
@@ -84,54 +70,62 @@
           method: 'POST'
         }).then(function(response) {
           return response.json();
-        }).then(function(answer) {
-          pc.remote_pc_id = answer.id;
-          return pc.setRemoteDescription(answer);
+        }).then(function(request) {
+          pc = new RTCPeerConnection({
+            sdpSemantics: 'unified-plan',
+            iceServers: request.iceServers
+          });
+          pc.remote_pc_id = request.id;
+          pc.addTransceiver('video', { direction: 'recvonly' });
+          pc.addEventListener('track', function(evt) {
+            if (document.getElementById('stream'))
+              document.getElementById('stream').srcObject = evt.streams[0];
+          });
+          pc.addEventListener("icecandidate", function(e) {
+            if (e.candidate) {
+              return fetch(window.location.href, {
+                body: JSON.stringify({
+                  type: 'remote_candidate',
+                  id: pc.remote_pc_id,
+                  candidates: [e.candidate]
+                }),
+                headers: { 'Content-Type': 'application/json' },
+                method: 'POST'
+              }).catch(function(e) {
+                console.log("Failed to send ICE WebRTC: "+e);
+              });
+            }
+          });
+
+          return pc.setRemoteDescription(request);
         }).then(function() {
           return pc.createAnswer();
         }).then(function(answer) {
           return pc.setLocalDescription(answer);
         }).then(function() {
-            // wait for ICE gathering to complete
-            return new Promise(function(resolve) {
-                if (pc.iceGatheringState === 'complete') {
-                    resolve();
-                } else {
-                    function checkState() {
-                        if (pc.iceGatheringState === 'complete') {
-                            pc.removeEventListener('icegatheringstatechange', checkState);
-                            resolve();
-                        }
-                    }
-                    pc.addEventListener('icegatheringstatechange', checkState);
-                }
-            });
-        }).then(function(answer) {
           var offer = pc.localDescription;
 
           return fetch(window.location.href, {
             body: JSON.stringify({
-                type: offer.type,
-                id: pc.remote_pc_id,
-                sdp: offer.sdp,
+              type: offer.type,
+              id: pc.remote_pc_id,
+              sdp: offer.sdp,
             }),
-            headers: {
-                'Content-Type': 'application/json'
-            },
+            headers: { 'Content-Type': 'application/json' },
             method: 'POST'
           })
         }).then(function(response) {
-            return response.json();
+          return response.json();
         }).catch(function(e) {
-            alert(e);
+          console.log(e);
         });
     }
 
     function stopWebRTC() {
-        setTimeout(function() {
-            pc.close();
-        }, 500);
-      }
+      setTimeout(function() {
+        pc.close();
+      }, 500);
+    }
   </script>
 
   <script>

--- a/output/webrtc/webrtc.cc
+++ b/output/webrtc/webrtc.cc
@@ -14,6 +14,7 @@ extern "C" {
 };
 
 #include "util/opts/helpers.hh"
+#include "util/http/json.hh"
 
 #ifdef USE_LIBDATACHANNEL
 
@@ -24,17 +25,19 @@ extern "C" {
 #include <atomic>
 #include <chrono>
 #include <set>
-#include <nlohmann/json.hpp>
 #include <rtc/peerconnection.hpp>
 #include <rtc/rtcpsrreporter.hpp>
 #include <rtc/h264rtppacketizer.hpp>
 #include <rtc/h264packetizationhandler.hpp>
 #include <rtc/rtcpnackresponder.hpp>
 
+#include "third_party/magic_enum/include/magic_enum.hpp"
+
 using namespace std::chrono_literals;
 
 class Client;
 
+static webrtc_options_t *webrtc_options;
 static std::set<std::shared_ptr<Client> > webrtc_clients;
 static std::mutex webrtc_clients_lock;
 static const auto webrtc_client_lock_timeout = 3 * 1000ms;
@@ -131,6 +134,32 @@ public:
     video->track->send(data);
   }
 
+  void describePeerConnection(nlohmann::json &message)
+  {
+    nlohmann::json ice_servers = nlohmann::json::array();
+
+    for (const auto &ice_server : pc->config()->iceServers) {
+      nlohmann::json json;
+
+      std::string url;
+
+      if (ice_server.type == rtc::IceServer::Type::Turn) {
+        json["username"] = ice_server.username;
+        json["credential"] = ice_server.password;
+        url = ice_server.relayType == rtc::IceServer::RelayType::TurnTls ? "turns:" : "turn:";
+      } else {
+        url = "stun:";
+      }
+
+      url += ice_server.hostname + ":" + std::to_string(ice_server.port);
+      json["urls"] = url;
+
+      ice_servers.push_back(json);
+    }
+
+    message["iceServers"] = ice_servers;
+  }
+
 public:
   char *name = NULL;
   std::string id;
@@ -138,11 +167,13 @@ public:
   std::shared_ptr<ClientTrackData> video;
   std::mutex lock;
   std::condition_variable wait_for_complete;
+  std::vector<rtc::Candidate> pending_remote_candidates;
+  bool has_set_sdp_answer = false;
   bool had_key_frame = false;
   bool requested_key_frame = false;
 };
 
-std::shared_ptr<Client> findClient(std::string id)
+std::shared_ptr<Client> webrtc_find_client(std::string id)
 {
   std::unique_lock lk(webrtc_clients_lock);
   for (auto client : webrtc_clients) {
@@ -154,14 +185,14 @@ std::shared_ptr<Client> findClient(std::string id)
   return std::shared_ptr<Client>();
 }
 
-void removeClient(const std::shared_ptr<Client> &client, const char *reason)
+static void webrtc_remove_client(const std::shared_ptr<Client> &client, const char *reason)
 {
   std::unique_lock lk(webrtc_clients_lock);
   webrtc_clients.erase(client);
   LOG_INFO(client.get(), "Client removed: %s.", reason);
 }
 
-std::shared_ptr<ClientTrackData> addVideo(const std::shared_ptr<rtc::PeerConnection> pc, const uint8_t payloadType, const uint32_t ssrc, const std::string cname, const std::string msid)
+static std::shared_ptr<ClientTrackData> webrtc_add_video(const std::shared_ptr<rtc::PeerConnection> pc, const uint8_t payloadType, const uint32_t ssrc, const std::string cname, const std::string msid)
 {
   auto video = rtc::Description::Video(cname, rtc::Description::Direction::SendOnly);
   video.addH264Codec(payloadType);
@@ -179,8 +210,50 @@ std::shared_ptr<ClientTrackData> addVideo(const std::shared_ptr<rtc::PeerConnect
   return std::shared_ptr<ClientTrackData>(new ClientTrackData{track, srReporter});
 }
 
-std::shared_ptr<Client> createPeerConnection(const rtc::Configuration &config)
+static void webrtc_parse_ice_servers(rtc::Configuration config, const nlohmann::json &message)
 {
+  auto ice_servers = message.find("ice_servers");
+  if (ice_servers == message.end() || !ice_servers->is_array())
+    return;
+
+  if (webrtc_options->disable_client_ice) {
+    LOG_VERBOSE(NULL, "ICE server from SDP request ignored due to `disable_client_ice`: %s",
+      ice_servers->dump().c_str());
+    return;
+  }
+
+  for (const auto& ice_server : *ice_servers) {
+    try {
+      auto urls = ice_server["urls"];
+
+      // convert non array to array
+      if (!urls.is_array()) {
+        urls = nlohmann::json::array();
+        urls.push_back(ice_server["urls"]);
+      }
+
+      for (const auto& url : urls) {
+        auto iceServer = rtc::IceServer(url.get<std::string>());
+        if (iceServer.type == rtc::IceServer::Type::Turn) {
+          iceServer.username = ice_server["username"].get<std::string>();
+          iceServer.password = ice_server["credential"].get<std::string>();
+        }
+
+        config.iceServers.push_back(iceServer);
+        LOG_VERBOSE(NULL, "Added ICE server from SDP request json: %s", url.dump().c_str());
+      }
+
+    } catch (nlohmann::detail::exception &e) {
+      LOG_VERBOSE(NULL, "Failed to parse ICE server: %s: %s",
+        ice_server.dump().c_str(), e.what());
+    }
+  }
+}
+
+static std::shared_ptr<Client> webrtc_peer_connection(rtc::Configuration config, const nlohmann::json &message)
+{
+  webrtc_parse_ice_servers(config, message);
+
   auto pc = std::make_shared<rtc::PeerConnection>(config);
   auto client = std::make_shared<Client>(pc);
   auto wclient = std::weak_ptr(client);
@@ -207,11 +280,15 @@ std::shared_ptr<Client> createPeerConnection(const rtc::Configuration &config)
     if(auto client = wclient.lock()) {
       LOG_DEBUG(client.get(), "onStateChange: %d", (int)state);
 
-      if (state == rtc::PeerConnection::State::Disconnected ||
+      if(state == rtc::PeerConnection::State::Connected) {
+        // Start streaming once the client is connected, to ensure a keyframe is sent to start the stream.
+        std::unique_lock lock(client->lock);
+        client->video->startStreaming();
+      } else if (state == rtc::PeerConnection::State::Disconnected ||
         state == rtc::PeerConnection::State::Failed ||
         state == rtc::PeerConnection::State::Closed)
       {
-        removeClient(client, "stream closed");
+        webrtc_remove_client(client, "stream closed");
       }
     }
   });
@@ -253,10 +330,10 @@ static void webrtc_h264_capture(buffer_lock_t *buf_lock, buffer_t *buf)
 
 static void http_webrtc_request(http_worker_t *worker, FILE *stream, const nlohmann::json &message)
 {
-  auto client = createPeerConnection(webrtc_configuration);
+  auto client = webrtc_peer_connection(webrtc_configuration, message);
   LOG_INFO(client.get(), "Stream requested.");
 
-  client->video = addVideo(client->pc, webrtc_client_video_payload_type, rand(), "video", "");
+  client->video = webrtc_add_video(client->pc, webrtc_client_video_payload_type, rand(), "video", "");
 
   try {
     {
@@ -271,6 +348,7 @@ static void http_webrtc_request(http_worker_t *worker, FILE *stream, const nlohm
       message["id"] = client->id;
       message["type"] = description->typeString();
       message["sdp"] = std::string(description.value());
+      client->describePeerConnection(message);
       http_write_response(stream, "200 OK", "application/json", message.dump().c_str(), 0);
       LOG_VERBOSE(client.get(), "Local SDP Offer: %s", std::string(message["sdp"]).c_str());
     } else {
@@ -278,7 +356,7 @@ static void http_webrtc_request(http_worker_t *worker, FILE *stream, const nlohm
     }
   } catch(const std::exception &e) {
     http_500(stream, e.what());
-    removeClient(client, e.what());
+    webrtc_remove_client(client, e.what());
   }
 }
 
@@ -289,18 +367,24 @@ static void http_webrtc_answer(http_worker_t *worker, FILE *stream, const nlohma
     return;
   }
 
-  if (auto client = findClient(message["id"])) {
+  if (auto client = webrtc_find_client(message["id"])) {
     LOG_INFO(client.get(), "Answer received.");
     LOG_VERBOSE(client.get(), "Remote SDP Answer: %s", std::string(message["sdp"]).c_str());
 
     try {
       auto answer = rtc::Description(std::string(message["sdp"]), std::string(message["type"]));
       client->pc->setRemoteDescription(answer);
-      client->video->startStreaming();
+      client->has_set_sdp_answer = true;
+
+      // If there are any pending candidates that make it in before the answer request, add them now.
+      for(auto const &candidate : client->pending_remote_candidates) {
+        client->pc->addRemoteCandidate(candidate);
+      }
+      client->pending_remote_candidates.clear();
       http_write_response(stream, "200 OK", "application/json", "{}", 0);
     } catch(const std::exception &e) {
       http_500(stream, e.what());
-      removeClient(client, e.what());
+      webrtc_remove_client(client, e.what());
     }
   } else {
     http_404(stream, "No client found");
@@ -315,18 +399,18 @@ static void http_webrtc_offer(http_worker_t *worker, FILE *stream, const nlohman
   }
 
   auto offer = rtc::Description(std::string(message["sdp"]), std::string(message["type"]));
-  auto client = createPeerConnection(webrtc_configuration);
+  auto client = webrtc_peer_connection(webrtc_configuration, message);
 
   LOG_INFO(client.get(), "Offer received.");
   LOG_VERBOSE(client.get(), "Remote SDP Offer: %s", std::string(message["sdp"]).c_str());
 
   try {
-    client->video = addVideo(client->pc, webrtc_client_video_payload_type, rand(), "video", "");
-    client->video->startStreaming();
+    client->video = webrtc_add_video(client->pc, webrtc_client_video_payload_type, rand(), "video", "");
 
     {
       std::unique_lock lock(client->lock);
       client->pc->setRemoteDescription(offer);
+      client->has_set_sdp_answer = true;
       client->pc->setLocalDescription();
       client->wait_for_complete.wait_for(lock, webrtc_client_lock_timeout);
     }
@@ -336,6 +420,7 @@ static void http_webrtc_offer(http_worker_t *worker, FILE *stream, const nlohman
       nlohmann::json message;
       message["type"] = description->typeString();
       message["sdp"] = std::string(description.value());
+      client->describePeerConnection(message);
       http_write_response(stream, "200 OK", "application/json", message.dump().c_str(), 0);
 
       LOG_VERBOSE(client.get(), "Local SDP Answer: %s", std::string(message["sdp"]).c_str());
@@ -344,32 +429,49 @@ static void http_webrtc_offer(http_worker_t *worker, FILE *stream, const nlohman
     }
   } catch(const std::exception &e) {
     http_500(stream, e.what());
-    removeClient(client, e.what());
+    webrtc_remove_client(client, e.what());
   }
 }
 
-nlohmann::json http_parse_json_body(http_worker_t *worker, FILE *stream)
+static void http_webrtc_remote_candidate(http_worker_t *worker, FILE *stream, const nlohmann::json &message)
 {
-  std::string text;
-
-  size_t i = 0;
-  size_t n = (size_t)worker->content_length;
-  if (n < 0 || n > webrtc_client_max_json_body)
-    n = webrtc_client_max_json_body;
-
-  text.resize(n);
-
-  while (i < n && !feof(stream)) {
-    i += fread(&text[i], 1, n-i, stream);
+  if (!message.contains("candidates") || !message.contains("id") || !message["candidates"].is_array()) {
+    http_400(stream, "candidates is not array or no id");
+    return;
   }
-  text.resize(i);
 
-  return nlohmann::json::parse(text);
+  auto client = webrtc_find_client(message["id"]);
+  if (!client) {
+    http_404(stream, "No client found");
+    return;
+  }
+
+  for (auto const & entry : message["candidates"]) {
+    try {
+      auto remoteCandidate = rtc::Candidate(
+        entry["candidate"].get<std::string>(),
+        entry["sdpMid"].get<std::string>());
+  
+      std::unique_lock lock(client->lock);
+      // The ICE candidate http requests can race the sdp answer http request and win. But it's invalid to set the ICE
+      // candidates before the SDP answer is set.
+      if (client->has_set_sdp_answer) {
+        client->pc->addRemoteCandidate(remoteCandidate);
+      } else {
+        client->pending_remote_candidates.push_back(remoteCandidate);
+      }
+    } catch (nlohmann::detail::exception &e) {
+      http_400(stream, e.what());
+      return;
+    }
+  }
+
+  http_write_response(stream, "200 OK", "application/json", "{}", 0);
 }
 
 extern "C" void http_webrtc_offer(http_worker_t *worker, FILE *stream)
 {
-  auto message = http_parse_json_body(worker, stream);
+  auto message = http_parse_json_body(worker, stream, webrtc_client_max_json_body);
 
   if (!message.contains("type")) {
     http_400(stream, "missing 'type'");
@@ -386,6 +488,8 @@ extern "C" void http_webrtc_offer(http_worker_t *worker, FILE *stream)
     http_webrtc_answer(worker, stream, message);
   } else if (type == "offer") {
     http_webrtc_offer(worker, stream, message);
+  } else if (type == "remote_candidate") {
+    http_webrtc_remote_candidate(worker, stream, message);
   } else {
     http_400(stream, (std::string("Not expected: " + type)).c_str());
   }
@@ -393,6 +497,8 @@ extern "C" void http_webrtc_offer(http_worker_t *worker, FILE *stream)
 
 extern "C" int webrtc_server(webrtc_options_t *options)
 {
+  webrtc_options = options;
+
   for (const auto &ice_server : str_split(options->ice_servers, OPTION_VALUE_LIST_SEP_CHAR)) {
     webrtc_configuration.iceServers.push_back(rtc::IceServer(ice_server));
   }

--- a/output/webrtc/webrtc.h
+++ b/output/webrtc/webrtc.h
@@ -10,6 +10,7 @@ typedef struct webrtc_options_s {
   bool running;
   bool disabled;
   char ice_servers[WEBRTC_OPTIONS_LENGTH];
+  bool disable_client_ice;
 } webrtc_options_t;
 
 // WebRTC

--- a/output/webrtc/webrtc.h
+++ b/output/webrtc/webrtc.h
@@ -2,11 +2,14 @@
 
 #include <stdio.h>
 
+#define WEBRTC_OPTIONS_LENGTH 4096
+
 typedef struct http_worker_s http_worker_t;
 
 typedef struct webrtc_options_s {
   bool running;
   bool disabled;
+  char ice_servers[WEBRTC_OPTIONS_LENGTH];
 } webrtc_options_t;
 
 // WebRTC

--- a/util/http/json.hh
+++ b/util/http/json.hh
@@ -1,0 +1,27 @@
+#pragma once
+
+extern "C" {
+#include "http.h"
+}
+
+#include <stdio.h>
+#include <nlohmann/json.hpp>
+
+inline nlohmann::json http_parse_json_body(http_worker_t *worker, FILE *stream, unsigned max_body_size)
+{
+  std::string text;
+
+  size_t i = 0;
+  size_t n = (size_t)worker->content_length;
+  if (n < 0 || n > max_body_size)
+    n = max_body_size;
+
+  text.resize(n);
+
+  while (i < n && !feof(stream)) {
+    i += fread(&text[i], 1, n-i, stream);
+  }
+  text.resize(i);
+
+  return nlohmann::json::parse(text);
+}

--- a/util/opts/helpers.hh
+++ b/util/opts/helpers.hh
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <sstream>
+
+inline std::vector<std::string> str_split(const std::string& in, const char seperator)
+{
+  std::vector<std::string> output;
+  std::istringstream stream(in);
+  for (std::string s; std::getline(stream, s, seperator); ) {
+    output.push_back(s);
+  }
+  return output;
+}

--- a/util/opts/opts.h
+++ b/util/opts/opts.h
@@ -26,6 +26,7 @@ typedef struct options_s {
   const char *description;
 } option_t;
 
+#define OPTION_VALUE_LIST_SEP_CHAR ';'
 #define OPTION_VALUE_LIST_SEP ";"
 
 #define OPTION_FORMAT_uint   "%u"


### PR DESCRIPTION
This change has a few minor fixes:

1. webrtc_parse_ice_servers config is passed by ref, otherwise, it's a copy of the config, and the servers added don't get used.
2. Turn servers don't require creds by the spec definition, so the creds are optional.
3. If debug logging is turned on for `camera-streamer`, `libdatachannel`'s logging is also enabled.