### PR TITLE
ffmpeg: remuxer: fix "initialization discards 'const' qualifier from pointer target type"

### DIFF
--- a/util/ffmpeg/remuxer.c
+++ b/util/ffmpeg/remuxer.c
@@ -94,7 +94,8 @@ int ffmpeg_remuxer_open(ffmpeg_remuxer_t *remuxer)
   if (remuxer->packet)
     return 0;
 
-  AVInputFormat *input_format = av_find_input_format(remuxer->input_format);
+  const AVInputFormat *input_format = av_find_input_format(remuxer->input_format);
+
   if (!input_format)
     return AVERROR(EINVAL);
 


### PR DESCRIPTION
The latest version of **ffmpeg** breaks the build across all branches and releases due to a type change of the overriden pointer. 

This PR fixes that error.