### PR TITLE
Add Breaks/Conflicts/Replaces to debian control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,9 @@ Rules-Requires-Root: no
 
 Package: camera-streamer-raspi
 Provides: camera-streamer
+Breaks: camera-streamer (<< 0.2)
+Conflicts: camera-streamer (<< 0.2)
+Replaces: camera-streamer (<< 0.2)
 Build-Profiles: <raspi>
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}


### PR DESCRIPTION
[As discussed on Discord a while ago](https://discord.com/channels/704958479194128507/888148195371278376/1115675307261821018), adding Breaks/Conflicts/Replaces entries against camera-streamer (<< 0.2) allows for a smooth migration from the camera-streamer package built for OctoPi to camera-streamer-raspi, through a transitional camera-streamer version 0.2 on OctoPi's side.

An upgrade of camera-streamer from OctoPrint's apt repo will pull in an updated transitional camera-streamer package version 0.2 that depends on camera-streamer-raspi. For that to install flawlessly in all cases, it needs to be installed *before* the camera-streamer-raspi dependency
(as some files between that and the former camera-streamer package overlap). By declaring Breaks/Conflicts/Replaces relationships on camera-streamer-raspi this is ensured.

I've manually adjusted `camera-streamer-raspi` and created a version `0.2.1~bullseye-1` to test this on a private apt repo and in all my test scenarios upgrades work with these changes:

- `apt upgrade` on a system that already has `camera-streamer` 0.1 pulls in the transitional package `camera-streamer` 0.2, which depends on `camera-streamer-raspi`, so that gets installed as well. apt does the install order the correct way only with the the additions in this PR
- `apt install camera-streamer-raspi` on a system that already has `camera-streamer` 0.1 upgrades both `camera-streamer` to the transitional 0.2 and installs `camera-streamer-raspi`
- `apt install camera-streamer-raspi` on a system that does NOT already have `camera-streamer` installed (so, OctoPi-UpToDate builds with the new camera stack going forward) only install `camera-streamer-raspi`