### PR TITLE
build: Remove temporary libssl package workaround

### DIFF
--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -13,9 +13,7 @@ RUN [ "$BUILD_TYPE" != "raspi" ] || \
     echo "deb http://archive.raspberrypi.org/debian/ $DEBIAN_VERSION main" > /etc/apt/sources.list.d/raspi.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9165938D90FDDD2E 82B129927FA3303E && \
     apt-get -y update && \
-    apt-get -y install libcamera-dev liblivemedia-dev && \
-    # Temporary workaround to RPI arm32 bug
-    ( [ "$(dpkg --print-architecture)" != "armhf" ] || apt-get --allow-downgrades -y install libssl1.1=1.1.1n-0+deb11u4+rpt1 ) \
+    apt-get -y install libcamera-dev liblivemedia-dev \
   )
 
 # Default packages


### PR DESCRIPTION
It seems to no longer be needed against current RPi arm32 packages and in fact makes the build fail as the package cannot be found any more:

```
Reading package lists...
Building dependency tree...
Reading state information...
E: Version '1.1.1n-0+deb11u4+rpt1' for 'libssl1.1' was not found
The command '/bin/sh -c [ "$BUILD_TYPE" != "raspi" ] ||   (     ( [ "$(dpkg --print-architecture)" != "armhf" ] || echo "deb http://raspbian.raspberrypi.org/raspbian/ $DEBIAN_VERSION main contrib non-free rpi" > /etc/apt/sources.list ) &&     echo "deb http://archive.raspberrypi.org/debian/ $DEBIAN_VERSION main" > /etc/apt/sources.list.d/raspi.list &&     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9165938D90FDDD2E 82B129927FA3303E &&     apt-get -y update &&     apt-get -y install libcamera-dev liblivemedia-dev &&     ( [ "$(dpkg --print-architecture)" != "armhf" ] || apt-get --allow-downgrades -y install libssl1.1=1.1.1n-0+deb11u4+rpt1 )   )' returned a non-zero code: 100

Error: Process completed with exit code 100.
```

Cross checking the current package definitions on raspbian.raspberrypi.org shows this as dependency for `libssl-dev`:

```
Package: libssl-dev
Source: openssl
Version: 1.1.1n-0+deb11u4
Architecture: armhf
[...]
Depends: libssl1.1 (= 1.1.1n-0+deb11u4)
```

And that's also what's available:

```
Package: libssl1.1
Source: openssl
Version: 1.1.1n-0+deb11u4
```