### PR TITLE
build: Support building new revisions for tags

### DIFF
--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -31,10 +31,11 @@ FROM build as deb_make
 ARG GIT_VERSION
 ARG BUILD_TYPE="generic"
 ENV DEB_BUILD_PROFILES="$BUILD_TYPE"
+ARG DEB_REVISION="1"
 
 RUN apt-get build-dep -y $PWD
 RUN . /etc/os-release && \
-  export RELEASE_SUFFIX="$VERSION_CODENAME" && \
+  export RELEASE_SUFFIX="$VERSION_CODENAME-$DEB_REVISION" && \
   dpkg-buildpackage -us -uc -b
 
 RUN mkdir -p /deb && mv ../*.deb /deb/

--- a/.github/workflows/build_revision.yaml
+++ b/.github/workflows/build_revision.yaml
@@ -1,0 +1,104 @@
+name: "Build package revisions for latest release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "release to revision"
+        required: false
+        default: ''
+      deb_revision:
+        description: "Revision to use for the debian packages"
+        required: false
+        default: ''
+
+jobs:
+  vars:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.get_tag.outputs.tag }}
+      revision: ${{ steps.get_revision.outputs.revision }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: recursive
+    - name: Determine latest tag
+      id: get_tag
+      run: |
+        set -e
+        tag="${{ github.event.inputs.tag }}"
+        if [[ -z "$tag" ]]; then
+          tag=$(git describe --tags --abbrev=0)
+        fi
+        echo "Set tag to $tag"
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        echo "GIT_VERSION=$tag" >> "$GITHUB_ENV"
+    - name: Determine latest revision
+      id: get_revision
+      run: |
+        set -e
+        revision="${{ github.event.inputs.deb_revision }}"
+        if [[ -z "$revision" ]]; then
+          current=$(curl -s https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${GIT_VERSION} | jq -r ".assets[].name" | grep "camera-streamer-raspi.*_armhf.deb" | cut -d "_" -f 2 | cut -d "-" -f 2 | sort -nr | head -n1)
+          echo "Found current revision $current"
+          revision=$(expr $current + 1)
+        fi
+        echo "Set revision to $revision"
+        echo "revision=$revision" >> "$GITHUB_OUTPUT"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: vars
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        debian_version: [bullseye]
+        docker_arch: [amd64, arm32v7, arm64v8]
+        build_type: [generic, raspi]
+        exclude:
+          - docker_arch: amd64
+            build_type: raspi
+          - debian_version: buster
+            build_type: raspi
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: recursive
+        ref: ${{ needs.vars.outputs.tag }}
+    - name: Set GIT_VERSION
+      run: echo "GIT_VERSION=$(git describe --tags)" >> $GITHUB_ENV
+    - name: Set DEB_REVISION
+      shell: bash
+      run: |
+        revision="${{ needs.vars.outputs.revision }}"
+        if [[ -n "$revision" ]]; then
+          echo "DEB_REVISION=${revision}" >> $GITHUB_ENV
+        else
+          echo "DEB_REVISION=1" >> $GITHUB_ENV
+        fi
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Build Dockerfile
+      run: docker build --target deb_make --tag deb_make --file .github/ci/Dockerfile --build-arg GIT_VERSION --build-arg DEB_REVISION --build-arg DOCKER_ARCH --build-arg DEBIAN_VERSION --build-arg BUILD_TYPE .
+      env:
+        DEBIAN_VERSION: ${{ matrix.debian_version }}
+        DOCKER_ARCH: ${{ matrix.docker_arch }}/
+        BUILD_TYPE: ${{ matrix.build_type }}
+    - name: Create container
+      run: docker create --name deb_make deb_make
+    - name: Copy files
+      run: 'docker cp deb_make:/deb/. deb/'
+    - name: 'Release debian files'
+      uses: ncipollo/release-action@v1
+      with:
+        tag: "${{ env.GIT_VERSION }}"
+        artifacts: "deb/*.deb"
+        allowUpdates: true
+        omitBodyDuringUpdate: true
+        omitNameDuringUpdate: true
+        omitPrereleaseDuringUpdate: true


### PR DESCRIPTION
A new action has been created in build_revision.yaml with a workflow dispatch that takes two optional input parameters, tag and revision.

If provided, the release with the tag will be adjusted with new builds versionened with the revision.

Otherwise the latest tag is determined, its release information fetched and the current package revision determined from that, then incremented by one to act as the new revision.

The goal of this action is to be able to do additional builds of the *same* code version, against a newer dependency versions (e.g. on a libcamera0 update). I have a workflow that implements this functionality as well and have that already running on OctoPrint's fork of this repo. It detects changed libcamera0 versions (scheduled check every our at the 42 minute mark) and triggers a revision build against the latest tag in such a case. Once this PR is merged I can provided that as well.

This should mean way less of an operational overhead to react to libcamera0 changes in the future, with fully automated PR generation against apt.octoprint.org as well (by an action that's already in place and operational there), and further possibilities like that for other projects. With a libcamera0 version pin being necessary the way it is, this is needed to keep maintenance on all sides feasible.