### PR TITLE
Add liveness check to WebRTC output using data channel

### DIFF
--- a/html/webrtc.html
+++ b/html/webrtc.html
@@ -73,6 +73,14 @@
             sdpSemantics: 'unified-plan',
             iceServers: request.iceServers
           });
+
+          pc.addEventListener('datachannel', function(e) {
+            const dc = e.channel;
+            dc.addEventListener('message', function(e) {
+              dc.send('pong');
+            });
+          });
+
           pc.remote_pc_id = request.id;
           pc.addTransceiver('video', { direction: 'recvonly' });
           pc.addEventListener('track', function(evt) {


### PR DESCRIPTION
Previously, there was no way to detect if WebRTC clients were still connected to the stream. This lead to the RTC streams being kept open indefinitely when clients focibly closed the stream. This can happen with Chrome, Edge, Safari, etc when the tab is closed or on mobile devices when the screen is locked or browser closed.

This change adds a data channel to the stream and requires users to respond to ping requests. A separate thread checks which the last time each client responded to a ping request and initiates new pings for clients that have not responded in some time (half the timeout duration). If clients do not respond to these ping requests before the timeout duration the stream is closed and the client is removed from the server. This causes the client to reinitiate the connection.

The timeout defaults to 30 seconds and is configurable via the cli option --webrtc-timeout.

Fixes ayufan/camera-streamer#55