### PR TITLE
fix: fix `make install` missing file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ version:
 %: cmd/% $(TARGET_OBJS)
 	$(CCACHE) $(CXX) $(CFLAGS) -o $@ $(filter-out cmd/%, $^) $(filter $</%, $^) $(LDLIBS)
 
-install: $(TARGET)
+install: version $(TARGET)
 	install $(TARGET) $(DESTDIR)/usr/local/bin/
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,10 @@ version:
 	diff -u version.h version.h.tmp || mv version.h.tmp version.h
 	-rm -f version.h.tmp
 
-%: version cmd/% $(TARGET_OBJS)
+%: cmd/% $(TARGET_OBJS)
 	$(CCACHE) $(CXX) $(CFLAGS) -o $@ $(filter-out cmd/%, $^) $(filter $</%, $^) $(LDLIBS)
 
-install: $(TARGET)
+install: version $(TARGET)
 	install $(TARGET) $(DESTDIR)/usr/local/bin/
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,10 @@ version:
 	diff -u version.h version.h.tmp || mv version.h.tmp version.h
 	-rm -f version.h.tmp
 
-%: cmd/% $(TARGET_OBJS)
+%: version cmd/% $(TARGET_OBJS)
 	$(CCACHE) $(CXX) $(CFLAGS) -o $@ $(filter-out cmd/%, $^) $(filter $</%, $^) $(LDLIBS)
 
-install: version $(TARGET)
+install: $(TARGET)
 	install $(TARGET) $(DESTDIR)/usr/local/bin/
 
 clean:


### PR DESCRIPTION
File Change:
- Makefile

Fix the missing `version.h` file when using `make install` directly.

How to reproduce the problem.
git clone the repo and update submodule in the repo. Then run the following command in camera-streamer directory. 
``` shell
sudo make install
```
After `make install` it will show missing `version.h`

It relate to the issue [ayufan/camera-streamer issue 111](https://github.com/ayufan/camera-streamer/issues/111) and [mainsail-crew/crowsnest issue 188](https://github.com/mainsail-crew/crowsnest/issues/188)

After this fix it can build with crowsnest.

-Neko.vecter