### PR TITLE
service examples using deprecated argument syntax

### DIFF
--- a/service/camera-streamer-arducam-16MP.service
+++ b/service/camera-streamer-arducam-16MP.service
@@ -5,27 +5,27 @@ ConditionPathExists=/sys/bus/i2c/drivers/imx519/10-001a/video4linux
 
 [Service]
 ExecStart=/usr/local/bin/camera-streamer \
-  -camera-path=/base/soc/i2c0mux/i2c@1/imx519@1a \
-  -camera-type=libcamera \
-  -camera-format=YUYV \
-  -camera-width=2328 -camera-height=1748 \
-  -camera-options=rotation=90 \
-  -camera-fps=15 \
+  --camera-path=/base/soc/i2c0mux/i2c@1/imx519@1a \
+  --camera-type=libcamera \
+  --camera-format=YUYV \
+  --camera-width=2328 --camera-height=1748 \
+  --camera-options=rotation=90 \
+  --camera-fps=15 \
   ; use two memory buffers to optimise usage
-  -camera-nbufs=2 \
+  --camera-nbufs=2 \
   ; the snapshot is 1438x1080
-  -camera-snapshot.height=1080 \
+  --camera-snapshot.height=1080 \
   ; the video/webrtc is 958x720
-  -camera-video.height=720 \
+  --camera-video.height=720 \
   ; the stream is 639x480
-  -camera-stream.height=480 \
+  --camera-stream.height=480 \
   ; bump brightness slightly
-  -camera-options=brightness=0.1 \
+  --camera-options=brightness=0.1 \
   ; disable auto-focus
-  -camera-auto_focus=1 \
+  --camera-auto_focus=1 \
   --http-listen=0.0.0.0 \
   --http-port=8080 \
-  -rtsp-port
+  --rtsp-port
 
 DynamicUser=yes
 SupplementaryGroups=video i2c

--- a/service/camera-streamer-arducam-64MP.service
+++ b/service/camera-streamer-arducam-64MP.service
@@ -8,26 +8,26 @@ ConditionPathExists=/sys/bus/i2c/drivers/arducam_64mp/10-001a/video4linux
 ExecStartPre=-/usr/bin/v4l2-ctl -d /dev/v4l-subdev1 -c focus_absolute=2200
 
 ExecStart=/usr/local/bin/camera-streamer \
-  -camera-path=/base/soc/i2c0mux/i2c@1/arducam_64mp@1a \
-  -camera-type=libcamera \
-  -camera-format=YUYV \
-  -camera-width=2328 -camera-height=1748 \
-  -camera-fps=30 \
+  --camera-path=/base/soc/i2c0mux/i2c@1/arducam_64mp@1a \
+  --camera-type=libcamera \
+  --camera-format=YUYV \
+  --camera-width=2328 --camera-height=1748 \
+  --camera-fps=30 \
   ; use two memory buffers to optimise usage
-  -camera-nbufs=2 \
+  --camera-nbufs=2 \
   ; the snapshot is 1438x1080
-  -camera-snapshot.height=1080 \
+  --camera-snapshot.height=1080 \
   ; the video/webrtc is 958x720
-  -camera-video.height=720 \
+  --camera-video.height=720 \
   ; the stream is 639x480
-  -camera-stream.height=480 \
+  --camera-stream.height=480 \
   ; bump brightness slightly
-  -camera-options=brightness=0.1 \
+  --camera-options=brightness=0.1 \
   ; disable auto-focus
-  -camera-auto_focus=0 \
+  --camera-auto_focus=0 \
   --http-listen=0.0.0.0 \
   --http-port=8080 \
-  -rtsp-port
+  --rtsp-port
 
 DynamicUser=yes
 SupplementaryGroups=video i2c

--- a/service/camera-streamer-generic-usb-cam.service
+++ b/service/camera-streamer-generic-usb-cam.service
@@ -5,17 +5,17 @@ ConditionPathExistsGlob=/dev/v4l/by-id/usb-*-video-index0
 
 [Service]
 ExecStart=/usr/local/bin/camera-streamer \
-  -camera-path=/dev/video0 \
-  -camera-format=JPEG \
-  -camera-width=1920 -camera-height=1080 \
-  -camera-fps=30 \
+  --camera-path=/dev/video0 \
+  --camera-format=JPEG \
+  --camera-width=1920 --camera-height=1080 \
+  --camera-fps=30 \
   ; use two memory buffers to optimise usage
-  -camera-nbufs=3 \
+  --camera-nbufs=3 \
   --http-listen=0.0.0.0 \
   --http-port=8080 \
   ; disable video streaming (WebRTC, RTSP, H264)
   ; on non-supported platforms
-  -camera-video.disabled
+  --camera-video.disabled
 
 DynamicUser=yes
 SupplementaryGroups=video i2c

--- a/service/camera-streamer-raspi-usb-cam.service
+++ b/service/camera-streamer-raspi-usb-cam.service
@@ -5,21 +5,21 @@ ConditionPathExistsGlob=/dev/v4l/by-id/usb-*-video-index0
 
 [Service]
 ExecStart=/usr/local/bin/camera-streamer \
-  -camera-path=/dev/video0 \
-  -camera-format=JPEG \
-  -camera-width=1920 -camera-height=1080 \
-  -camera-fps=30 \
+  --camera-path=/dev/video0 \
+  --camera-format=JPEG \
+  --camera-width=1920 --camera-height=1080 \
+  --camera-fps=30 \
   ; use two memory buffers to optimise usage
-  -camera-nbufs=3 \
+  --camera-nbufs=3 \
   ; the high-res is 1920x1080
-  -camera-snapshot.height=1080 \
+  --camera-snapshot.height=1080 \
   ; the video/webrtc is 1280x720
-  -camera-video.height=720 \
+  --camera-video.height=720 \
   ; the stream is 853x480
-  -camera-stream.height=480 \
+  --camera-stream.height=480 \
   --http-listen=0.0.0.0 \
   --http-port=8080 \
-  -rtsp-port
+  --rtsp-port
 
 DynamicUser=yes
 SupplementaryGroups=video i2c

--- a/service/camera-streamer-raspi-v2-8MP.service
+++ b/service/camera-streamer-raspi-v2-8MP.service
@@ -9,24 +9,24 @@ ConditionPathExists=/sys/bus/i2c/drivers/imx219/10-0010/video4linux
 
 [Service]
 ExecStart=/usr/local/bin/camera-streamer \
-  -camera-path=/base/soc/i2c0mux/i2c@1/imx219@10 \
-  -camera-type=libcamera \
-  -camera-format=YUYV \
-  -camera-width=3280 -camera-height=2464 \
-  -camera-fps=30 \
+  --camera-path=/base/soc/i2c0mux/i2c@1/imx219@10 \
+  --camera-type=libcamera \
+  --camera-format=YUYV \
+  --camera-width=3280 --camera-height=2464 \
+  --camera-fps=30 \
   ; use two memory buffers to optimise usage
-  -camera-nbufs=2 \
+  --camera-nbufs=2 \
   ; the snapshot is 1438x1080
-  -camera-snapshot.height=1080 \
+  --camera-snapshot.height=1080 \
   ; the video/webrtc is 958x720
-  -camera-video.height=720 \
+  --camera-video.height=720 \
   ; the stream is 639x480
-  -camera-stream.height=480 \
+  --camera-stream.height=480 \
   ; bump brightness slightly
-  -camera-options=brightness=0.1 \
+  --camera-options=brightness=0.1 \
   --http-listen=0.0.0.0 \
   --http-port=8080 \
-  -rtsp-port
+  --rtsp-port
 
 DynamicUser=yes
 SupplementaryGroups=video i2c

--- a/service/camera-streamer-raspi-v3-12MP.service
+++ b/service/camera-streamer-raspi-v3-12MP.service
@@ -9,25 +9,25 @@ ConditionPathExists=/sys/bus/i2c/drivers/imx708/10-001a/video4linux
 
 [Service]
 ExecStart=/usr/local/bin/camera-streamer \
-  -camera-path=/base/soc/i2c0mux/i2c@1/imx708@1a \
-  -camera-type=libcamera \
-  -camera-format=YUYV \
-  -camera-width=2304 -camera-height=1296 \
-  -camera-fps=30 \
+  --camera-path=/base/soc/i2c0mux/i2c@1/imx708@1a \
+  --camera-type=libcamera \
+  --camera-format=YUYV \
+  --camera-width=2304 --camera-height=1296 \
+  --camera-fps=30 \
   ; use two memory buffers to optimise usage
-  -camera-nbufs=2 \
+  --camera-nbufs=2 \
   ; the snapshot is 1920x1080
-  -camera-snapshot.height=1080 \
+  --camera-snapshot.height=1080 \
   ; the video/webrtc is 1280x720
-  -camera-video.height=720 \
+  --camera-video.height=720 \
   ; the stream is 853x480
-  -camera-stream.height=480 \
+  --camera-stream.height=480 \
   ; enable continuous autofocus
-  -camera-options=AfMode=2 \
-  -camera-options=AfRange=2 \
+  --camera-options=AfMode=2 \
+  --camera-options=AfRange=2 \
   --http-listen=0.0.0.0 \
   --http-port=8080 \
-  -rtsp-port
+  --rtsp-port
 
 DynamicUser=yes
 SupplementaryGroups=video i2c


### PR DESCRIPTION
many options in the example services are using single dash, where teh opt code calls these out in the log as deprecated and should move to double dashs.

this pull changes the example service options to double dashs to remove errors from the logs and aligns with the help dialog and documentation.

