### PR TITLE
Fix bytesperline calculation for libcamera0.2

### DIFF
--- a/device/libcamera/buffer_list.cc
+++ b/device/libcamera/buffer_list.cc
@@ -92,6 +92,8 @@ int libcamera_buffer_list_open(buffer_list_t *buf_list)
   }
   if (buf_list->fmt.bytesperline > 0) {
     configuration.stride = buf_list->fmt.bytesperline;
+  } else {
+    configuration.stride = 0;
   }
   if (buf_list->fmt.nbufs > 0) {
     configuration.bufferCount = buf_list->fmt.nbufs;


### PR DESCRIPTION
For libcamera0.2 `configuraiton.stride` is already set to some incorrect value and `configurations->validate()` doesn't update it if it's not 0.

For libcamera0.1 it was set to 0. So set it to 0 manually to make sure `configurations->validate()` computes the correct value.

Before:
```
device/buffer_list.c: CAMERA:capture: Using: 1920x1080/YUYV, buffers=3, bytesperline=3840, sizeimage=0.0MiB
device/buffer_list.c: CAMERA:capture:1: Using: 2304x1296/BG10, buffers=3, bytesperline=5760, sizeimage=0.0MiB
ERROR V4L2 v4l2_videodevice.cpp:1697 /dev/video13[26:out]: Failed to queue buffer 0: Invalid argument
ERROR RPISTREAM rpi_stream.cpp:276 Failed to queue buffer for ISP Input
```

After:
```
device/buffer_list.c: CAMERA:capture: Using: 1920x1080/YUYV, buffers=3, bytesperline=3840, sizeimage=0.0MiB
device/buffer_list.c: CAMERA:capture:1: Using: 2304x1296/BG10, buffers=3, bytesperline=2880, sizeimage=0.0MiB
```

Tested both with libcamera0.1 and libcamera0.2 on raspberry pi 4. Errors are gone and streaming works fine with libcamera0.2 finally.

Thanks to @tom-ard for help with debugging.

Fixes #139 