### PR TITLE
libcamera: fix compilation errors for libcamera v0.3.2+rpt20241119

### DIFF
--- a/device/libcamera/options.cc
+++ b/device/libcamera/options.cc
@@ -465,7 +465,7 @@ int libcamera_device_set_option(device_t *dev, const char *keyp, const char *val
 
     case libcamera::ControlTypeString:
       break;
-    
+
     case libcamera::ControlTypePoint:
       libcamera_parse_control_value<libcamera::Point>(
         control_value, value, libcamera_parse_point);

--- a/device/libcamera/options.cc
+++ b/device/libcamera/options.cc
@@ -359,6 +359,7 @@ static libcamera::Size libcamera_parse_size(const char *value)
   return libcamera::Size();
 }
 
+#if LIBCAMERA_VERSION_MAJOR == 0 && LIBCAMERA_VERSION_MINOR > 3 && LIBCAMERA_VERSION_PATCH >= 2 // Support for older libcamera versions
 static libcamera::Point libcamera_parse_point(const char *value)
 {
   static const char *POINT_PATTERNS[] =
@@ -379,6 +380,7 @@ static libcamera::Point libcamera_parse_point(const char *value)
 
   return libcamera::Point();
 }
+#endif
 
 template<typename T, typename F>
 static bool libcamera_parse_control_value(libcamera::ControlValue &control_value, const char *value, const F &fn)

--- a/device/libcamera/options.cc
+++ b/device/libcamera/options.cc
@@ -222,6 +222,9 @@ static int libcamera_device_dump_control_option(device_option_fn fn, void *opaqu
     opt.type = device_option_type_float;
     opt.elems = 2;
     break;
+
+  default:
+    throw std::runtime_error("ControlType unsupported or not implemented");
   }
 
   auto named_values = libcamera_find_control_ids(control_id.id());
@@ -467,6 +470,9 @@ int libcamera_device_set_option(device_t *dev, const char *keyp, const char *val
       libcamera_parse_control_value<libcamera::Point>(
         control_value, value, libcamera_parse_point);
       break;
+
+    default:
+      throw std::runtime_error("ControlType unsupported or not implemented");
     }
 
     if (control_value.isNone()) {

--- a/device/libcamera/options.cc
+++ b/device/libcamera/options.cc
@@ -468,10 +468,12 @@ int libcamera_device_set_option(device_t *dev, const char *keyp, const char *val
     case libcamera::ControlTypeString:
       break;
 
+#if LIBCAMERA_VERSION_MAJOR == 0 && LIBCAMERA_VERSION_MINOR > 3 && LIBCAMERA_VERSION_PATCH >= 2 // Support for older libcamera versions
     case libcamera::ControlTypePoint:
       libcamera_parse_control_value<libcamera::Point>(
         control_value, value, libcamera_parse_point);
       break;
+#endif
 
     default:
       throw std::runtime_error("ControlType unsupported or not implemented");

--- a/device/libcamera/options.cc
+++ b/device/libcamera/options.cc
@@ -217,6 +217,11 @@ static int libcamera_device_dump_control_option(device_option_fn fn, void *opaqu
   case libcamera::ControlTypeString:
     opt.type = device_option_type_string;
     break;
+
+  case libcamera::ControlTypePoint:
+    opt.type = device_option_type_float;
+    opt.elems = 2;
+    break;
   }
 
   auto named_values = libcamera_find_control_ids(control_id.id());
@@ -349,6 +354,27 @@ static libcamera::Size libcamera_parse_size(const char *value)
   return libcamera::Size();
 }
 
+static libcamera::Point libcamera_parse_point(const char *value)
+{
+  static const char *POINT_PATTERNS[] =
+  {
+    "(%d,%d)",
+    "%d,%d",
+    NULL
+  };
+
+  for (int i = 0; POINT_PATTERNS[i]; i++) {
+    libcamera::Point point;
+
+    if (2 == sscanf(value, POINT_PATTERNS[i],
+      &point.x, &point.y)) {
+      return point;
+    }
+  }
+
+  return libcamera::Point();
+}
+
 template<typename T, typename F>
 static bool libcamera_parse_control_value(libcamera::ControlValue &control_value, const char *value, const F &fn)
 {
@@ -435,6 +461,11 @@ int libcamera_device_set_option(device_t *dev, const char *keyp, const char *val
       break;
 
     case libcamera::ControlTypeString:
+      break;
+    
+    case libcamera::ControlTypePoint:
+      libcamera_parse_control_value<libcamera::Point>(
+        control_value, value, libcamera_parse_point);
       break;
     }
 

--- a/device/libcamera/options.cc
+++ b/device/libcamera/options.cc
@@ -218,10 +218,12 @@ static int libcamera_device_dump_control_option(device_option_fn fn, void *opaqu
     opt.type = device_option_type_string;
     break;
 
+#if LIBCAMERA_VERSION_MAJOR == 0 && LIBCAMERA_VERSION_MINOR > 3 && LIBCAMERA_VERSION_PATCH >= 2 // Support for older libcamera versions
   case libcamera::ControlTypePoint:
     opt.type = device_option_type_float;
     opt.elems = 2;
     break;
+#endif
 
   default:
     throw std::runtime_error("ControlType unsupported or not implemented");


### PR DESCRIPTION
Fixes #161
This PR adds a default case to throw an error during runtime instead of compilation, if a `ControlType` is not implemented yet.

This also adds parsing for the new [`ControlTypePoint`](https://github.com/raspberrypi/libcamera/commit/200d535ca85f23e6c562335c5d9badb5be4db28f) added with libcamera [v0.3.2+rpt20241119](https://github.com/raspberrypi/libcamera/releases/tag/v0.3.2%2Brpt20241119).

This might break compilation for libcamera [v0.3.2+rpt20240927](https://github.com/raspberrypi/libcamera/releases/tag/v0.3.2%2Brpt20240927) and [v0.3.2+rpt20241119](https://github.com/raspberrypi/libcamera/releases/tag/v0.3.2%2Brpt20241119).