### PR TITLE
http: decode POST parameters before applying options.

### DIFF
--- a/util/http/http.h
+++ b/util/http/http.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <pthread.h>
 #include <netinet/ip.h>
 


### PR DESCRIPTION
Also decode POST arguments, so if you set option like ScalerCrop fro web UI you will get it correctly applied.
For example set via web ui: ScalerCrop to (964,436)/3000x1920

With fix:
util/http/http.c: HTTP8080/5: Request 'POST' '/option' 'device=CAMERA&key=scalercrop&value=(964%2C436)%2F3000x1920' device/libcamera/options.cc: CAMERA: Configuring option 'ScalerCrop' (0000001b, type=9) = (964, 436)/3000x1920

Fixes https://github.com/ayufan/camera-streamer/issues/115