### PR TITLE
rtsp: disable RTSP support if using old livemedia version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ GIT_REVISION ?= $(shell git rev-parse --short HEAD)
 CFLAGS := -Werror -Wall -g -I$(CURDIR) -D_GNU_SOURCE
 LDLIBS := -lpthread -lstdc++
 
+# Print #warnings
+CFLAGS += -Wno-error=cpp
+
 # libdatachannel deprecations on bookworm
 # error: 'HMAC_Init_ex' is deprecated: Since OpenSSL 3.0
 CFLAGS += -Wno-error=deprecated-declarations

--- a/output/rtsp/rtsp.cc
+++ b/output/rtsp/rtsp.cc
@@ -14,6 +14,13 @@ extern "C" {
 };
 
 #ifdef USE_RTSP
+#if !__has_include(<RTSPServerSupportingHTTPStreaming.hh>)
+#undef USE_RTSP
+#warning "Missing RTSPServerSupportingHTTPStreaming.hh header. The RTSP support will be missing."
+#endif // RTSPServerSupportingHTTPStreaming.hh
+#endif // USE_RTSP
+
+#ifdef USE_RTSP
 
 #include <string>
 #include <memory>


### PR DESCRIPTION
The `RTSPServerSupportingHTTPStreaming.hh` is missing on newer distros.

Skip compiling RTSP if header is missing.