### PR TITLE
Add liveness check to WebRTC output using data channel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ LDLIBS := -lpthread -lstdc++
 # Print #warnings
 CFLAGS += -Wno-error=cpp
 
+# LOG_*(this, ...)
+CFLAGS += -Wno-error=nonnull-compare
+
 # libdatachannel deprecations on bookworm
 # error: 'HMAC_Init_ex' is deprecated: Since OpenSSL 3.0
 CFLAGS += -Wno-error=deprecated-declarations

--- a/html/control.html
+++ b/html/control.html
@@ -759,7 +759,11 @@
       ];
 
       fetch(baseURL + webrtcURL, {
-        body: JSON.stringify({type: 'request', iceServers: iceServers}),
+        body: JSON.stringify({
+          type: 'request',
+          iceServers: iceServers,
+          keepAlive: true
+        }),
         headers: {'Content-Type': 'application/json'},
         method: 'POST'
       }).then(function(response) {
@@ -768,6 +772,12 @@
         rtcPeerConnection = new RTCPeerConnection({
           sdpSemantics: 'unified-plan',
           iceServers: request.iceServers
+        });
+        rtcPeerConnection.addEventListener('datachannel', function(e) {
+          const dc = e.channel;
+          dc.addEventListener('message', function(e) {
+            dc.send('pong');
+          });
         });
         rtcPeerConnection.addTransceiver('video', { direction: 'recvonly' });
         //pc.addTransceiver('audio', {direction: 'recvonly'});

--- a/html/webrtc.html
+++ b/html/webrtc.html
@@ -73,6 +73,14 @@
             sdpSemantics: 'unified-plan',
             iceServers: request.iceServers
           });
+
+          pc.addEventListener('datachannel', function(e) {
+            const dc = e.channel;
+            dc.addEventListener('message', function(e) {
+              dc.send('pong');
+            });
+          });
+
           pc.remote_pc_id = request.id;
           pc.addTransceiver('video', { direction: 'recvonly' });
           pc.addEventListener('track', function(evt) {

--- a/html/webrtc.html
+++ b/html/webrtc.html
@@ -60,7 +60,8 @@
           body: JSON.stringify({
               type: 'request',
               res: params.res,
-              iceServers: iceServers
+              iceServers: iceServers,
+              keepAlive: true
           }),
           headers: {
               'Content-Type': 'application/json'


### PR DESCRIPTION
This supersedes the https://github.com/ayufan/camera-streamer/pull/91.

Changes:

- client needs to send `keepAlive: true` as part of request to enable Keep-Alives
  - no threads, the ping/pong are checked while sending frame
  - the ping is sent every second
  - the pong needs to be received at least once per-30s
- the `timeout_s` is introduced as part of request
  - client will be disconnected after the desired timeout
  - the default value is 3600 seconds => 1 hour
  - the `timeout_s: 0` disables timeout
